### PR TITLE
Quay Zitadel OIDC / Quay DragonFly

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -144,6 +144,7 @@
         "discordapp",
         "dnsmasq",
         "dockerconfigjson",
+        "dragonflydb",
         "dtzar",
         "dumpxml",
         "easyeffects",

--- a/kubernetes/quay/base/config.yaml
+++ b/kubernetes/quay/base/config.yaml
@@ -54,6 +54,21 @@ stringData:
     FEATURE_UI_V2: true
     FEATURE_QUOTA_MANAGEMENT: true
     DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: 10737418240 #10GB
+    ZITADEL_LOGIN_CONFIG:
+      CLIENT_ID: <path:secret/data/homelab/quay/zitadel#client_id>
+      CLIENT_SECRET: <path:secret/data/homelab/quay/zitadel#client_secret>
+      LOGIN_SCOPES:
+      - profile
+      OIDC_SERVER: https://zitadel.apps.okd.<path:secret/data/homelab/domain#url>/
+      PREFERRED_USERNAME_CLAIM_NAME: preferred_username
+      SERVICE_NAME: Zitadel
+      VERIFIED_EMAIL_CLAIM_NAME: email
+    BUILDLOGS_REDIS:
+      host: quay-dragonfly.quay.svc.cluster.local
+      port: 6379
+    USER_EVENTS_REDIS:
+      host: quay-dragonfly.quay.svc.cluster.local
+      port: 6379
 
   clair-config.yaml: |
     indexer:

--- a/kubernetes/quay/base/dragonfly/dragonfly.yaml
+++ b/kubernetes/quay/base/dragonfly/dragonfly.yaml
@@ -1,0 +1,16 @@
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: quay-dragonfly
+  namespace: quay
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  replicas: 2
+  resources:
+    limits:
+      cpu: 250m
+      memory: 384Mi
+    requests:
+      cpu: 75m
+      memory: 128Mi

--- a/kubernetes/quay/base/dragonfly/network-policy.yaml
+++ b/kubernetes/quay/base/dragonfly/network-policy.yaml
@@ -1,0 +1,161 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dragonfly
+  namespace: quay
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    app.kubernetes.io/instance: quay
+spec:
+  podSelector:
+    matchLabels:
+      app: quay-dragonfly
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/part-of: dragonfly
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: quay
+          podSelector:
+            matchLabels:
+              app: quay-dragonfly
+              app.kubernetes.io/name: dragonfly
+              app.kubernetes.io/part-of: dragonfly
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: quay
+          podSelector:
+            matchLabels:
+              app: quay-dragonfly
+              app.kubernetes.io/name: dragonfly
+              app.kubernetes.io/part-of: dragonfly
+      ports:
+        - protocol: TCP
+          port: 6379
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dragonfly-quay
+  namespace: quay
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    app.kubernetes.io/instance: quay
+spec:
+  podSelector:
+    matchLabels:
+      app: quay-dragonfly
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/part-of: dragonfly
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: quay
+          podSelector:
+            matchLabels:
+              app: quay
+              app.kubernetes.io/instance: quay
+              app.kubernetes.io/name: quay
+      ports:
+        - protocol: TCP
+          port: 6379
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dragonfly-quay-egress
+  namespace: quay
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app.kubernetes.io/instance: quay
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: quay
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: quay
+          podSelector:
+            matchLabels:
+              app: quay-dragonfly
+              app.kubernetes.io/name: dragonfly
+              app.kubernetes.io/part-of: dragonfly
+      ports:
+        - port: 6379
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-internet-egress-dragonfly
+  namespace: quay
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app.kubernetes.io/instance: quay
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app: quay-dragonfly
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/part-of: dragonfly
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+        - ipBlock:
+            cidr: 10.0.0.100/32
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dragonfly-operator-system
+  namespace: quay
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    app.kubernetes.io/instance: quay
+spec:
+  podSelector:
+    matchLabels:
+      app: quay-dragonfly
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/part-of: dragonfly
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: dragonfly-operator-system
+          podSelector:
+            matchLabels:
+              control-plane: controller-manager
+      ports:
+        - protocol: TCP
+          port: 9999

--- a/kubernetes/quay/base/kustomization.yaml
+++ b/kubernetes/quay/base/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - ./config.yaml
   - ./installplan-approver.yaml
   - ./minio/tenant.yaml
+  - ./dragonfly/dragonfly.yaml
+  - ./dragonfly/network-policy.yaml

--- a/kubernetes/quay/base/quay.yaml
+++ b/kubernetes/quay/base/quay.yaml
@@ -17,7 +17,7 @@ spec:
     - kind: objectstorage
       managed: false
     - kind: redis
-      managed: true
+      managed: false
     - kind: horizontalpodautoscaler
       managed: false
     - kind: route

--- a/kubernetes/quay/base/resource-quota.yaml
+++ b/kubernetes/quay/base/resource-quota.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   hard:
     requests.cpu: "20"
-    requests.memory: "50Gi"
+    requests.memory: "64Gi"
     limits.cpu: "40"
-    limits.memory: "100Gi"
+    limits.memory: "128Gi"
     services.nodeports: "0"
     services.loadbalancers: "0"
     requests.ephemeral-storage: "10Gi"

--- a/kubernetes/zitadel/base/cockroachdb.yaml
+++ b/kubernetes/zitadel/base/cockroachdb.yaml
@@ -24,7 +24,7 @@ spec:
       cpu: 100m
       memory: 1536Mi
     limits:
-      cpu: 500m
+      cpu: 750m
       memory: 3Gi
   tlsEnabled: true
   image:

--- a/kubernetes/zitadel/base/deployment.yaml
+++ b/kubernetes/zitadel/base/deployment.yaml
@@ -37,14 +37,22 @@ spec:
           effect: NoSchedule
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/master
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
                     operator: In
                     values:
-                      - "true"
+                      - ""
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: NotIn
+                    values:
+                      - zitadel
+              topologyKey: topology.kubernetes.io/zone
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 1
@@ -139,11 +147,11 @@ spec:
               mountPath: /.secrets
           resources:
             limits:
-              cpu: 500m
-              memory: 256Mi
+              cpu: 1000m
+              memory: 512Mi
             requests:
               cpu: 100m
-              memory: 128Mi
+              memory: 256Mi
       initContainers:
         - args:
             - "cp -r /db-ssl-user-crt/ /chowned-secrets/ && cp -r /db-ssl-ca-crt/ /chowned-secrets/ && cp -r /zitadel-secrets-yaml/ /chowned-secrets/ && find /chowned-secrets/ -type f -exec chmod 400 -- {} + "


### PR DESCRIPTION
- Enable OIDC For Quay with Zitadel
   - Quay OIDC Health Check is too sensitive, increase resources for Zitadel and Cockroachdb
-  Enable HA DragonFly to Replace Redis For Quay