### PR TITLE
feat: switch from route to ingress

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -323,6 +323,7 @@
     "mkpasswd",
     "moreutils",
     "mountsatoken",
+    "mtls",
     "multiband",
     "mutatingwebhookconfigurations",
     "myminio",

--- a/kubernetes/gitea/overlays/okd/route.yaml
+++ b/kubernetes/gitea/overlays/okd/route.yaml
@@ -1,20 +1,22 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: gitea
   namespace: gitea
   labels:
-    app: gitea
     app.kubernetes.io/instance: gitea
+  annotations:
+    route.openshift.io/termination: passthrough
 spec:
-  host: "git.arthurvardevanyan.com"
-  to:
-    kind: Service
-    name: gitea-http
-    weight: 100
-  port:
-    targetPort: http
-  tls:
-    termination: passthrough
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: git.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: gitea-http
+                port:
+                  name: http

--- a/kubernetes/grafana/overlays/okd/route.yaml
+++ b/kubernetes/grafana/overlays/okd/route.yaml
@@ -1,20 +1,22 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: grafana
   namespace: grafana
   labels:
-    app: grafana
-    app.kubernetes.io/instance: grafana
+    app.kubernetes.io/instance: gitea
+  annotations:
+    route.openshift.io/termination: edge
 spec:
-  host: grafana.apps.okd.<path:secret/data/homelab/domain#url>
-  to:
-    kind: Service
-    name: grafana
-    weight: 100
-  port:
-    targetPort: 3000
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: grafana.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: grafana
+                port:
+                  name: http

--- a/kubernetes/heimdall/overlays/okd/route.yaml
+++ b/kubernetes/heimdall/overlays/okd/route.yaml
@@ -1,20 +1,22 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: heimdall
   namespace: heimdall
   labels:
-    app: heimdall
     app.kubernetes.io/instance: heimdall
+  annotations:
+    route.openshift.io/termination: edge
 spec:
-  host: heimdall.apps.okd.<path:secret/data/homelab/domain#url>
-  to:
-    kind: Service
-    name: heimdall
-    weight: 100
-  port:
-    targetPort: 80
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: heimdall.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: heimdall
+                port:
+                  name: http-80

--- a/kubernetes/homeassistant/base/service.yaml
+++ b/kubernetes/homeassistant/base/service.yaml
@@ -12,5 +12,6 @@ spec:
     - protocol: TCP
       port: 8123
       targetPort: 8123
+      name: https
   type: ClusterIP
   clusterIP: None

--- a/kubernetes/homeassistant/overlays/okd/route.yaml
+++ b/kubernetes/homeassistant/overlays/okd/route.yaml
@@ -1,20 +1,22 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: homeassistant
   namespace: homeassistant
   labels:
-    app: homeassistant
     app.kubernetes.io/instance: homeassistant
+  annotations:
+    route.openshift.io/termination: passthrough
 spec:
-  host: "home.<path:secret/data/homelab/domain#url>"
-  to:
-    kind: Service
-    name: homeassistant
-    weight: 100
-  port:
-    targetPort: 8123
-  tls:
-    termination: passthrough
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: home.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: homeassistant
+                port:
+                  name: https

--- a/kubernetes/influxdb/base/service.yaml
+++ b/kubernetes/influxdb/base/service.yaml
@@ -13,7 +13,7 @@ spec:
     - name: "2003"
       port: 2003
       targetPort: 2003
-    - name: "8086"
+    - name: http
       port: 8086
       targetPort: 8086
   selector:

--- a/kubernetes/influxdb/overlays/okd/route.yaml
+++ b/kubernetes/influxdb/overlays/okd/route.yaml
@@ -1,20 +1,22 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: influxdb
   namespace: influxdb
   labels:
-    app: influxdb
     app.kubernetes.io/instance: influxdb
+  annotations:
+    route.openshift.io/termination: edge
 spec:
-  host: influxdb.apps.okd.<path:secret/data/homelab/domain#url>
-  to:
-    kind: Service
-    name: influxdb
-    weight: 100
-  port:
-    targetPort: 8086
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: influxdb.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: influxdb
+                port:
+                  name: http

--- a/kubernetes/loki/base/route.yaml
+++ b/kubernetes/loki/base/route.yaml
@@ -1,20 +1,22 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: loki
   namespace: loki
   labels:
-    app: loki
     app.kubernetes.io/instance: loki
+  annotations:
+    route.openshift.io/termination: edge
 spec:
-  host: loki.apps.okd.<path:secret/data/homelab/domain#url>
-  to:
-    kind: Service
-    name: loki
-    weight: 100
-  port:
-    targetPort: http-metrics
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: loki.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: loki
+                port:
+                  name: http-metrics

--- a/kubernetes/longhorn/components/okd/route.yaml
+++ b/kubernetes/longhorn/components/okd/route.yaml
@@ -1,5 +1,5 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: longhorn-ui
   namespace: longhorn-system
@@ -8,12 +8,18 @@ metadata:
     app.kubernetes.io/instance: longhorn
     app.kubernetes.io/version: v1.5.3
     app: longhorn-ui
+  annotations:
+    route.openshift.io/termination: reencrypt
 spec:
-  host: ""
-  to:
-    kind: Service
-    name: longhorn-ui
-  tls:
-    termination: reencrypt
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: ""
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: longhorn-ui
+                port:
+                  name: longhorn-ui

--- a/kubernetes/longhorn/overlays/okd-sandbox/kustomization.yaml
+++ b/kubernetes/longhorn/overlays/okd-sandbox/kustomization.yaml
@@ -6,9 +6,9 @@ components:
   - ../../components/okd
 patches:
   - target:
-      kind: Route
-      name: ui
+      kind: Ingress
+      name: longhorn-ui
     patch: |-
       - op: replace
-        path: /spec/host
-        value: longhorn.apps.okd.sandbox.<path:secret/data/homelab/domain#url>
+        path: /spec/rules/0/host
+        value: longhorn.apps.okd.sandbox.arthurvardevanyan.com

--- a/kubernetes/longhorn/overlays/okd/kustomization.yaml
+++ b/kubernetes/longhorn/overlays/okd/kustomization.yaml
@@ -8,9 +8,9 @@ components:
   - ../../components/okd
 patches:
   - target:
-      kind: Route
+      kind: Ingress
       name: longhorn-ui
     patch: |-
       - op: replace
-        path: /spec/host
-        value: longhorn.apps.okd.<path:secret/data/homelab/domain#url>
+        path: /spec/rules/0/host
+        value: longhorn.apps.okd.arthurvardevanyan.com

--- a/kubernetes/minio-operator/overlays/okd/route.yaml
+++ b/kubernetes/minio-operator/overlays/okd/route.yaml
@@ -1,17 +1,22 @@
-apiVersion: route.openshift.io/v1
-kind: Route
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
-  labels:
-    app.kubernetes.io/instance: minio-operator
   name: minio-operator
   namespace: minio-operator
+  labels:
+    app.kubernetes.io/instance: minio-operator
+  annotations:
+    route.openshift.io/termination: edge
 spec:
-  host: minio-operator.apps.okd.<path:secret/data/homelab/domain#url>
-  port:
-    targetPort: http
-  to:
-    kind: Service
-    name: console
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect
+  ingressClassName: openshift-default
+  rules:
+    - host: minio-operator.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: console
+                port:
+                  name: http

--- a/kubernetes/nextcloud/base/service.yaml
+++ b/kubernetes/nextcloud/base/service.yaml
@@ -12,5 +12,6 @@ spec:
     - protocol: TCP
       port: 443
       targetPort: 8443
+      name: https
   type: ClusterIP
   clusterIP: None

--- a/kubernetes/nextcloud/overlays/okd/route.yaml
+++ b/kubernetes/nextcloud/overlays/okd/route.yaml
@@ -1,20 +1,22 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: nextcloud
   namespace: nextcloud
   labels:
-    app: nextcloud
     app.kubernetes.io/instance: nextcloud
+  annotations:
+    route.openshift.io/termination: passthrough
 spec:
-  host: nextcloud.<path:secret/data/homelab/domain#url>
-  to:
-    kind: Service
-    name: nextcloud
-    weight: 100
-  port:
-    targetPort: 8443
-  tls:
-    termination: passthrough
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: nextcloud.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: nextcloud
+                port:
+                  name: https

--- a/kubernetes/photoprism/overlays/okd/route.yaml
+++ b/kubernetes/photoprism/overlays/okd/route.yaml
@@ -1,20 +1,22 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: photoprism
   namespace: photoprism
   labels:
-    app: photoprism
     app.kubernetes.io/instance: photoprism
+  annotations:
+    route.openshift.io/termination: edge
 spec:
-  host: photoprism.apps.okd.<path:secret/data/homelab/domain#url>
-  to:
-    kind: Service
-    name: photoprism
-    weight: 100
-  port:
-    targetPort: 2342
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: photoprism.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: photoprism
+                port:
+                  name: http

--- a/kubernetes/phpmyadmin/overlays/okd/route.yaml
+++ b/kubernetes/phpmyadmin/overlays/okd/route.yaml
@@ -1,20 +1,23 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: phpmyadmin
   namespace: mariadb-galera
   labels:
     app: phpmyadmin
     app.kubernetes.io/instance: phpmyadmin
+  annotations:
+    route.openshift.io/termination: edge
 spec:
-  host: phpmyadmin.apps.okd.<path:secret/data/homelab/domain#url>
-  to:
-    kind: Service
-    name: phpmyadmin
-    weight: 100
-  port:
-    targetPort: 8080
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: phpmyadmin.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: phpmyadmin
+                port:
+                  name: web

--- a/kubernetes/prometheus/overlays/okd/route.yaml
+++ b/kubernetes/prometheus/overlays/okd/route.yaml
@@ -1,41 +1,45 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: prometheus
   namespace: prometheus
   labels:
-    app: prometheus
     app.kubernetes.io/instance: prometheus
+  annotations:
+    route.openshift.io/termination: edge
 spec:
-  host: prometheus.apps.okd.<path:secret/data/homelab/domain#url>
-  to:
-    kind: Service
-    name: prometheus-service
-    weight: 100
-  port:
-    targetPort: 9090
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: prometheus.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: prometheus-service
+                port:
+                  name: metrics
 ---
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: thanos-querier
   namespace: prometheus
   labels:
-    app: prometheus
     app.kubernetes.io/instance: prometheus
+  annotations:
+    route.openshift.io/termination: edge
 spec:
-  host: thanos-querier.apps.okd.<path:secret/data/homelab/domain#url>
-  to:
-    kind: Service
-    name: thanos-querier
-    weight: 100
-  port:
-    targetPort: http
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: thanos-querier.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: thanos-querier
+                port:
+                  name: http

--- a/kubernetes/stackrox-central/overlays/okd/route.yaml
+++ b/kubernetes/stackrox-central/overlays/okd/route.yaml
@@ -1,6 +1,6 @@
 # Source: stackrox-central-services/templates/01-central-15-exposure.yaml
-apiVersion: route.openshift.io/v1
-kind: Route
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: central
   namespace: stackrox
@@ -17,18 +17,24 @@ metadata:
     meta.helm.sh/release-name: stackrox-central-services
     meta.helm.sh/release-namespace: stackrox
     owner: stackrox
+    route.openshift.io/termination: passthrough
 spec:
-  port:
-    targetPort: https
-  tls:
-    termination: passthrough
-  to:
-    kind: Service
-    name: central
+  ingressClassName: openshift-default
+  rules:
+    - host: central-stackrox.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: central
+                port:
+                  name: https
 ---
 # Source: stackrox-central-services/templates/01-central-15-exposure.yaml
-apiVersion: route.openshift.io/v1
-kind: Route
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: central-mtls
   namespace: stackrox
@@ -46,11 +52,15 @@ metadata:
     meta.helm.sh/release-namespace: stackrox
     owner: stackrox
 spec:
-  host: "central.stackrox"
-  port:
-    targetPort: https
-  tls:
-    termination: passthrough
-  to:
-    kind: Service
-    name: central
+  ingressClassName: openshift-default
+  rules:
+    - host: central.stackrox
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: central
+                port:
+                  name: https

--- a/kubernetes/tekton/components/okd/route.yaml
+++ b/kubernetes/tekton/components/okd/route.yaml
@@ -1,22 +1,24 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: tekton
   namespace: openshift-pipelines
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
   labels:
     app: tekton
     app.kubernetes.io/instance: tekton
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    route.openshift.io/termination: edge
 spec:
-  host: tekton.apps.okd.<path:secret/data/homelab/domain#url>
-  to:
-    kind: Service
-    name: tekton-dashboard
-    weight: 100
-  port:
-    targetPort: 9097
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: tekton.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: tekton-dashboard
+                port:
+                  name: http

--- a/kubernetes/uptime-kuma/base/service.yaml
+++ b/kubernetes/uptime-kuma/base/service.yaml
@@ -14,3 +14,4 @@ spec:
     - protocol: TCP
       port: 3001
       targetPort: 3001
+      name: http

--- a/kubernetes/uptime-kuma/overlays/okd/route.yaml
+++ b/kubernetes/uptime-kuma/overlays/okd/route.yaml
@@ -1,20 +1,22 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: uptime-kuma
   namespace: uptime-kuma
   labels:
-    app: uptime-kuma
     app.kubernetes.io/instance: uptime-kuma
+  annotations:
+    route.openshift.io/termination: edge
 spec:
-  host: uptime.apps.okd.<path:secret/data/homelab/domain#url>
-  to:
-    kind: Service
-    name: uptime-kuma-service
-    weight: 100
-  port:
-    targetPort: 3001
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: uptime.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: uptime-kuma-service
+                port:
+                  name: http

--- a/kubernetes/vault/overlays/okd/route.yaml
+++ b/kubernetes/vault/overlays/okd/route.yaml
@@ -1,20 +1,22 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: vault
   namespace: vault
   labels:
-    app: vault
     app.kubernetes.io/instance: vault
+  annotations:
+    route.openshift.io/termination: passthrough
 spec:
-  host: vault.<path:secret/data/homelab/domain#url>
-  to:
-    kind: Service
-    name: vault
-    weight: 100
-  port:
-    targetPort: vault
-  tls:
-    termination: passthrough
-    insecureEdgeTerminationPolicy: Redirect
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: vault.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: vault
+                port:
+                  name: vault

--- a/kubernetes/zitadel/base/route.yaml
+++ b/kubernetes/zitadel/base/route.yaml
@@ -1,35 +1,45 @@
-apiVersion: route.openshift.io/v1
-kind: Route
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: crdb
   namespace: zitadel
+  labels:
+    app.kubernetes.io/instance: zitadel
+  annotations:
+    route.openshift.io/termination: passthrough
 spec:
-  host: db-zitadel.apps.okd.<path:secret/data/homelab/domain#url>
-  port:
-    targetPort: http
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: passthrough
-  to:
-    kind: Service
-    name: crdb-public
-    weight: 100
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: db-zitadel.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: crdb-public
+                port:
+                  name: http
 ---
-apiVersion: route.openshift.io/v1
-kind: Route
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: zitadel
   namespace: zitadel
+  labels:
+    app.kubernetes.io/instance: zitadel
+  annotations:
+    route.openshift.io/termination: edge
 spec:
-  host: zitadel.apps.okd.<path:secret/data/homelab/domain#url>
-  port:
-    targetPort: http2-server
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-  to:
-    kind: Service
-    name: zitadel
-    weight: 100
-  wildcardPolicy: None
+  ingressClassName: openshift-default
+  rules:
+    - host: zitadel.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: ""
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: zitadel
+                port:
+                  name: http2-server

--- a/tekton/base/triggers/route.yaml
+++ b/tekton/base/triggers/route.yaml
@@ -1,17 +1,20 @@
-kind: Route
-apiVersion: route.openshift.io/v1
+kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
-  name: el
+  name: homelab
   namespace: homelab
   labels:
-    app: homelab
     app.kubernetes.io/instance: homelab
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  to:
-    kind: Service
-    name: el-webhook
-    weight: 100
-  port:
-    targetPort: 8080
+  ingressClassName: openshift-default
+  rules:
+    - host: el-homelab.apps.okd.arthurvardevanyan.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: el-webhook
+                port:
+                  name: http-listener


### PR DESCRIPTION
Ingress supports all the features that a Route does, for distribution consistency, using ingress provides a more Kubernetes native solution.

TODO: Move Ingress from Overlay to Base and and update to use patches for K3S Cluster.