### PR TITLE
fix: Add Long Lived Token for oAuthProxy Apps

### DIFF
--- a/kubernetes/longhorn/components/okd/kustomization.yaml
+++ b/kubernetes/longhorn/components/okd/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - prometheus-rbac.yaml
   - service-monitor.yaml
   - prometheus-rules.yaml
+  - secret.yaml

--- a/kubernetes/longhorn/components/okd/route.yaml
+++ b/kubernetes/longhorn/components/okd/route.yaml
@@ -1,5 +1,5 @@
-kind: Ingress
-apiVersion: networking.k8s.io/v1
+kind: Route
+apiVersion: route.openshift.io/v1
 metadata:
   name: longhorn-ui
   namespace: longhorn-system
@@ -8,18 +8,12 @@ metadata:
     app.kubernetes.io/instance: longhorn
     app.kubernetes.io/version: v1.6.0
     app: longhorn-ui
-  annotations:
-    route.openshift.io/termination: reencrypt
 spec:
-  ingressClassName: openshift-default
-  rules:
-    - host: ""
-      http:
-        paths:
-          - path: ""
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: longhorn-ui
-                port:
-                  name: longhorn-ui
+  host: ""
+  to:
+    kind: Service
+    name: longhorn-ui
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/kubernetes/longhorn/components/okd/secret.yaml
+++ b/kubernetes/longhorn/components/okd/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: longhorn-ui-service-account
+  annotations:
+    kubernetes.io/service-account.name: longhorn-ui-service-account
+type: kubernetes.io/service-account-token

--- a/kubernetes/longhorn/overlays/okd/kustomization.yaml
+++ b/kubernetes/longhorn/overlays/okd/kustomization.yaml
@@ -9,9 +9,9 @@ components:
   - ../../components/backup
 patches:
   - target:
-      kind: Ingress
+      kind: Route
       name: longhorn-ui
     patch: |-
       - op: replace
-        path: /spec/rules/0/host
+        path: /spec/host
         value: longhorn.apps.okd.arthurvardevanyan.com

--- a/kubernetes/stackrox-central/base/secret.yaml
+++ b/kubernetes/stackrox-central/base/secret.yaml
@@ -1,4 +1,11 @@
-# ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: central
+  annotations:
+    kubernetes.io/service-account.name: central
+type: kubernetes.io/service-account-token
+---
 # # Source: stackrox-central-services/templates/01-central-04-htpasswd-secret.yaml
 # apiVersion: v1
 # kind: Secret

--- a/kubernetes/stackrox-central/overlays/okd/route.yaml
+++ b/kubernetes/stackrox-central/overlays/okd/route.yaml
@@ -1,6 +1,6 @@
 # Source: stackrox-central-services/templates/01-central-15-exposure.yaml
-kind: Ingress
-apiVersion: networking.k8s.io/v1
+apiVersion: route.openshift.io/v1
+kind: Route
 metadata:
   name: central
   namespace: stackrox
@@ -17,24 +17,18 @@ metadata:
     meta.helm.sh/release-name: stackrox-central-services
     meta.helm.sh/release-namespace: stackrox
     owner: stackrox
-    route.openshift.io/termination: passthrough
 spec:
-  ingressClassName: openshift-default
-  rules:
-    - host: central-stackrox.apps.okd.arthurvardevanyan.com
-      http:
-        paths:
-          - path: ""
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: central
-                port:
-                  name: https
+  port:
+    targetPort: https
+  tls:
+    termination: passthrough
+  to:
+    kind: Service
+    name: central
 ---
 # Source: stackrox-central-services/templates/01-central-15-exposure.yaml
-kind: Ingress
-apiVersion: networking.k8s.io/v1
+apiVersion: route.openshift.io/v1
+kind: Route
 metadata:
   name: central-mtls
   namespace: stackrox
@@ -52,15 +46,11 @@ metadata:
     meta.helm.sh/release-namespace: stackrox
     owner: stackrox
 spec:
-  ingressClassName: openshift-default
-  rules:
-    - host: central.stackrox
-      http:
-        paths:
-          - path: ""
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: central
-                port:
-                  name: https
+  host: "central.stackrox"
+  port:
+    targetPort: https
+  tls:
+    termination: passthrough
+  to:
+    kind: Service
+    name: central


### PR DESCRIPTION
- 4.15 Removes Default Long Lived Secrets, oAuthProxy Requires this.
- oAuthProxy doesn't like ingress objects.