### PR TITLE
chore(OKD Upgrade): 4.16.0-0.okd-scos-2024-08-01-132038

### DIFF
--- a/main.bash
+++ b/main.bash
@@ -947,10 +947,6 @@ delete_okd() {
   export HOME=/home/arthur
   export HOMELAB="${PWD}"
 
-  if swapon --show | grep -q "${SWAP_PATH}"; then
-    swapoff /home/swapfile.img
-  fi
-
   echo -e "\n\n${BLUE}Delete OKD Install:${NC}"
 
   echo -e "\n\n${BLUE}Delete Bootstrap:${NC}"
@@ -973,6 +969,10 @@ delete_okd() {
   cd "${HOMELAB}/terraform/sandbox/cluster"
   terraform destroy -auto-approve
 
+  if swapon --show | grep -q "${SWAP_PATH}"; then
+    swapoff /home/swapfile.img
+  fi
+
   cd "${HOMELAB}"
 }
 
@@ -980,10 +980,6 @@ delete_okd_agent() {
   export HOME=/home/arthur
   export HOMELAB="${PWD}"
   export OKD=/mnt/storage/okd
-
-  if swapon --show | grep -q "${SWAP_PATH}"; then
-    swapoff /home/swapfile.img
-  fi
 
   # TODO, Automate Finding Which IPs to Remove
   # TODO Stop Running as Sudo
@@ -1005,6 +1001,10 @@ delete_okd_agent() {
     "${OKD}"/fedora-coreos-* \
     "${OKD}"/*.qcow2 \
     "${OKD}"/okd
+
+  if swapon --show | grep -q "${SWAP_PATH}"; then
+    swapoff /home/swapfile.img
+  fi
 
   cd "${HOMELAB}"
 }

--- a/okd/okd-configuration/base/image-mirror-set.yaml
+++ b/okd/okd-configuration/base/image-mirror-set.yaml
@@ -16,6 +16,10 @@ spec:
     # #   source: registry.ci.openshift.org/origin/release
     #   mirrorSourcePolicy: AllowContactingSource
     - mirrors:
+        - registry.arthurvardevanyan.com/okd
+      source: quay.io/okd
+      mirrorSourcePolicy: AllowContactingSource
+    - mirrors:
         - registry.arthurvardevanyan.com/openshift
       source: quay.io/openshift
       mirrorSourcePolicy: AllowContactingSource

--- a/okd/okd-configuration/overlays/okd/cluster-version.yaml
+++ b/okd/okd-configuration/overlays/okd/cluster-version.yaml
@@ -9,6 +9,6 @@ spec:
   clusterID: <path:secret/data/okd#cluster_id>
   desiredUpdate:
     force: false
-    image: quay.io/openshift/okd@sha256:46b462be1e4c15ce5ab5fba97e713e8824bbb9f614ac5abe1be41fda916920cc
-    version: 4.15.0-0.okd-2024-03-10-010116
+    image: quay.io/okd/scos-release@sha256:2a83e5f31710cf5eec7dd699374994d6402bc203f0d2c4b00a5ace6b309b146c
+    version: 4.16.0-0.okd-scos-2024-08-01-132038
   upstream: https://amd64.origin.releases.ci.openshift.org/graph


### PR DESCRIPTION
Manual Intervention Required:
- https://github.com/okd-project/okd/discussions/1971#discussioncomment-10119718 
 - https://github.com/okd-project/okd/discussions/1971#discussioncomment-10120175

```bash
oc adm release info --image-for=hyperkube quay.io/okd/scos-release:4.16.0-0.okd-scos-2024-08-01-132038
oc adm release info --image-for=cluster-kube-apiserver-operator quay.io/okd/scos-release:4.16.0-0.okd-scos-2024-08-01-132038


quay.io/okd/scos-content@sha256:340136746073e163e8aebccbcbedd549e421eb00daef6fecf8608cb43e120571
quay.io/okd/scos-content@sha256:37d6b6c13d864deb7ea925acf2b2cb34305333f92ce64e7906d3f973a8071642

oc edit -n openshift-kube-apiserver-operator deployments/kube-apiserver-operator
```