### PR TITLE
feat(NTP): Multus 'Active/Passive Load Balancing'

### DIFF
--- a/kubernetes/nmstate/overlays/okd/network/nad.yaml
+++ b/kubernetes/nmstate/overlays/okd/network/nad.yaml
@@ -31,3 +31,20 @@ spec:
     "topology":"localnet",
     "netAttachDefName": "default/enp7s0f1-nad-vlan11"
     }'
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: enp7s0f1-nad-vlan111
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "name": "br1.111",
+    "type": "ovn-k8s-cni-overlay",
+    "topology":"localnet",
+    "netAttachDefName": "default/enp7s0f1-nad-vlan111"
+    }'

--- a/kubernetes/ntp/components/rootless/deployment.yaml
+++ b/kubernetes/ntp/components/rootless/deployment.yaml
@@ -21,10 +21,27 @@ spec:
       annotations:
         enable.version-checker.io/ntp-rootless: "true"
         seccomp.security.alpha.kubernetes.io/defaultProfileName: "runtime/default"
+        k8s.v1.cni.cncf.io/networks: |
+          [{
+            "name": "enp7s0f1-nad-vlan3",
+            "namespace": "default",
+            "mac": "10:01:02:00:30:05",
+            "ips": ["10.102.3.5/24"]
+          },
+          {
+            "name": "enp7s0f1-nad-vlan111",
+            "namespace": "default",
+            "mac": "10:01:01:00:10:05",
+            "ips": ["10.101.1.5/24"],
+            "default-route": ["10.101.1.1"]
+          }]
     spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+        sysctls:
+          - name: net.ipv4.ip_unprivileged_port_start
+            value: "0"
         runAsNonRoot: true
       hostname: ntp-rootless
       restartPolicy: Always
@@ -39,7 +56,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: ntp-rootless
           ports:
-            - containerPort: 12345
+            - containerPort: 123 #12345
               name: ntp
               protocol: UDP
           securityContext:
@@ -50,6 +67,8 @@ spec:
             seccompProfile:
               type: RuntimeDefault
             capabilities:
+              add:
+                - NET_BIND_SERVICE
               drop:
                 - ALL
           resources:
@@ -65,7 +84,7 @@ spec:
             - name: SKIP_CHOWN
               value: "true"
             - name: PORT
-              value: "12345"
+              value: "123" # 12345
             - name: CMDPORT
               value: "10323"
             - name: ENABLE_NTS

--- a/kubernetes/ntp/components/rootless/kustomization.yaml
+++ b/kubernetes/ntp/components/rootless/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - ./deployment.yaml
-  - ./service.yaml
+  # - ./service.yaml

--- a/kubernetes/ntp/overlays/okd/kustomization.yaml
+++ b/kubernetes/ntp/overlays/okd/kustomization.yaml
@@ -4,21 +4,21 @@ resources:
   - ../../base
   - ./egress-firewall.yaml
   - ./pdb.yaml
-  - ./dns.yaml
+  # - ./dns.yaml
 components:
   - ../../components/rootless
-patches:
-  - target:
-      kind: Service
-      name: ntp-rootless
-    patch: |-
-      - op: replace
-        path: /metadata/annotations/kube-vip.io~1loadbalancerIPs
-        value: "10.0.0.95"
-  - target:
-      kind: Service
-      name: ntp-rootless-vlan3
-    patch: |-
-      - op: replace
-        path: /metadata/annotations/kube-vip.io~1loadbalancerIPs
-        value: "10.102.3.3"
+# patches:
+#   - target:
+#       kind: Service
+#       name: ntp-rootless
+#     patch: |-
+#       - op: replace
+#         path: /metadata/annotations/kube-vip.io~1loadbalancerIPs
+#         value: "10.0.0.95"
+#   - target:
+#       kind: Service
+#       name: ntp-rootless-vlan3
+#     patch: |-
+#       - op: replace
+#         path: /metadata/annotations/kube-vip.io~1loadbalancerIPs
+#         value: "10.102.3.3"


### PR DESCRIPTION
Presently Unable to Drop Native LBs onto separate VLANs, using this as a workaround. 

Of the two replicas, due to the NAD, only one is active at any time on the network. 