### PR TITLE
chore(MTU): Adjust for Kube-Vip Load Balancing

### DIFF
--- a/kubernetes/ceph/overlays/okd/nncp.yaml
+++ b/kubernetes/ceph/overlays/okd/nncp.yaml
@@ -8,7 +8,7 @@ spec:
       - name: enp7s0f0
         type: ethernet
         state: up
-        mtu: 9000
+        mtu: 3897
         ipv4:
           enabled: true
           dhcp: true
@@ -22,7 +22,7 @@ spec:
           base-iface: enp7s0f0
           mode: bridge
           promiscuous: true
-        mtu: 9000
+        mtu: 3897
         ipv4:
           enabled: true
           dhcp: true
@@ -41,7 +41,7 @@ spec:
       - name: enp10s0
         type: ethernet
         state: up
-        mtu: 9000
+        mtu: 3897
         ipv4:
           enabled: true
           dhcp: true

--- a/kubernetes/kubevirt/overlays/okd/nad.yaml
+++ b/kubernetes/kubevirt/overlays/okd/nad.yaml
@@ -8,7 +8,7 @@ spec:
       - name: enp7s0f1
         type: ethernet
         state: up
-        mtu: 9000
+        mtu: 3897
         ipv4:
           enabled: true
           dhcp: true

--- a/kubernetes/nmstate/overlays/okd/network/nncp.yaml
+++ b/kubernetes/nmstate/overlays/okd/network/nncp.yaml
@@ -17,7 +17,7 @@ spec:
         vlan:
           base-iface: enp7s0f1
           id: 3
-        mtu: 9000
+        mtu: 3897
       - name: br1.3
         description: OVS bridge with enp7s0f1.3 as a port
         type: ovs-bridge
@@ -32,7 +32,7 @@ spec:
               enabled: false
           port:
             - name: enp7s0f1.3
-        mtu: 9000
+        mtu: 3897
     ovn:
       bridge-mappings:
         - localnet: br1.3
@@ -58,7 +58,7 @@ spec:
         vlan:
           base-iface: enp7s0f1
           id: 11
-        mtu: 9000
+        mtu: 3897
       - name: br1.11
         description: OVS bridge with enp7s0f1.11 as a port
         type: ovs-bridge
@@ -73,7 +73,7 @@ spec:
               enabled: false
           port:
             - name: enp7s0f1.11
-        mtu: 9000
+        mtu: 3897
     ovn:
       bridge-mappings:
         - localnet: br1.11
@@ -99,7 +99,7 @@ spec:
         vlan:
           base-iface: enp7s0f1
           id: 111
-        mtu: 9000
+        mtu: 3897
       - name: br1.111
         description: OVS bridge with enp7s0f1.111 as a port
         type: ovs-bridge
@@ -114,7 +114,7 @@ spec:
               enabled: false
           port:
             - name: enp7s0f1.111
-        mtu: 9000
+        mtu: 3897
     ovn:
       bridge-mappings:
         - localnet: br1.111


### PR DESCRIPTION
In Cluster Load Balancing (kube-vip), does not function on the primary interface when a secondary interface has an mtu higher then 3897?

