### PR TITLE
fix(CentOS10): Network Interface Rename

### DIFF
--- a/kubernetes/ceph/overlays/okd/nncp.yaml
+++ b/kubernetes/ceph/overlays/okd/nncp.yaml
@@ -21,9 +21,9 @@ spec:
           mode: active-backup
           options:
             miimon: "150"
-            primary: enp1s0f1
+            primary: enp1s0f1np1
           port:
-            - enp1s0f1
+            - enp1s0f1np1
             - enp7s0f0
       - name: ceph-pub-shim
         description: Shim interface used to connect host to OpenShift Data Foundation public Multus network
@@ -65,9 +65,9 @@ spec:
           mode: active-backup
           options:
             miimon: "150"
-            primary: enp1s0f1
+            primary: enp1s0f1np1
           port:
-            - enp1s0f1
+            - enp1s0f1np1
             - enp7s0f0
       - name: ceph-pub-shim
         description: Shim interface used to connect host to OpenShift Data Foundation public Multus network
@@ -109,9 +109,9 @@ spec:
           mode: active-backup
           options:
             miimon: "150"
-            primary: enp1s0f1
+            primary: enp1s0f1np1
           port:
-            - enp1s0f1
+            - enp1s0f1np1
             - enp7s0f0
       - name: ceph-pub-shim
         description: Shim interface used to connect host to OpenShift Data Foundation public Multus network
@@ -153,9 +153,9 @@ spec:
           mode: active-backup
           options:
             miimon: "150"
-            primary: enp1s0f2
+            primary: enp1s0f2np2
           port:
-            - enp1s0f2
+            - enp1s0f2np2
             - enp10s0
 ---
 apiVersion: nmstate.io/v1
@@ -181,9 +181,9 @@ spec:
           mode: active-backup
           options:
             miimon: "150"
-            primary: enp1s0f2
+            primary: enp1s0f2np2
           port:
-            - enp1s0f2
+            - enp1s0f2np2
             - enp10s0
 ---
 apiVersion: nmstate.io/v1
@@ -209,7 +209,7 @@ spec:
           mode: active-backup
           options:
             miimon: "150"
-            primary: enp1s0f2
+            primary: enp1s0f2np2
           port:
-            - enp1s0f2
+            - enp1s0f2np2
             - enp10s0

--- a/kubernetes/kubevirt/overlays/okd/nad.yaml
+++ b/kubernetes/kubevirt/overlays/okd/nad.yaml
@@ -21,9 +21,9 @@ spec:
           mode: active-backup
           options:
             miimon: "150"
-            primary: enp1s0f3
+            primary: enp1s0f3np3
           port:
-            - enp1s0f3
+            - enp1s0f3np3
             - enp7s0f1
 ---
 apiVersion: nmstate.io/v1
@@ -49,9 +49,9 @@ spec:
           mode: active-backup
           options:
             miimon: "150"
-            primary: enp1s0f3
+            primary: enp1s0f3np3
           port:
-            - enp1s0f3
+            - enp1s0f3np3
             - enp7s0f1
 ---
 apiVersion: nmstate.io/v1
@@ -77,9 +77,9 @@ spec:
           mode: active-backup
           options:
             miimon: "150"
-            primary: enp1s0f3
+            primary: enp1s0f3np3
           port:
-            - enp1s0f3
+            - enp1s0f3np3
             - enp7s0f1
 ---
 apiVersion: "k8s.cni.cncf.io/v1"

--- a/okd/agent-config.yaml
+++ b/okd/agent-config.yaml
@@ -9,13 +9,13 @@ hosts:
     rootDeviceHints:
       deviceName: "/dev/disk/by-path/pci-0000:02:00.1-ata-4.0"
     interfaces:
-      - name: enp1s0f0
+      - name: enp1s0f0np0
         macAddress: 98:b7:85:22:14:04
-      - name: enp1s0f1
+      - name: enp1s0f1np1
         macAddress: 98:b7:85:22:14:05
-      - name: enp1s0f2
+      - name: enp1s0f2np2
         macAddress: 98:b7:85:22:14:06
-      - name: enp1s0f3
+      - name: enp1s0f3np3
         macAddress: 98:b7:85:22:14:07
       - name: enp6s0
         macAddress: b0:19:21:53:e0:2c
@@ -44,18 +44,18 @@ hosts:
             mode: active-backup
             options:
               miimon: "150"
-              primary: enp1s0f0
+              primary: enp1s0f0np0
             port:
-              - enp1s0f0
+              - enp1s0f0np0
               - enp6s0
-        - name: enp1s0f1
-          description: enp1s0f1
+        - name: enp1s0f1np1
+          description: enp1s0f1np1
           state: down
-        - name: enp1s0f2
-          description: enp1s0f2
+        - name: enp1s0f2np2
+          description: enp1s0f2np2
           state: down
-        - name: enp1s0f3
-          description: enp1s0f3
+        - name: enp1s0f3np3
+          description: enp1s0f3np3
           state: down
         - name: enp6s0
           description: enp6s0
@@ -83,13 +83,13 @@ hosts:
     rootDeviceHints:
       deviceName: "/dev/disk/by-path/pci-0000:02:00.1-ata-4.0"
     interfaces:
-      - name: enp1s0f0
+      - name: enp1s0f0np0
         macAddress: 98:b7:85:21:ed:db
-      - name: enp1s0f1
+      - name: enp1s0f1np1
         macAddress: 98:b7:85:21:ed:dc
-      - name: enp1s0f2
+      - name: enp1s0f2np2
         macAddress: 98:b7:85:21:ed:dd
-      - name: enp1s0f3
+      - name: enp1s0f3np3
         macAddress: 98:b7:85:21:ed:de
       - name: enp6s0
         macAddress: b0:19:21:53:d5:50
@@ -118,18 +118,18 @@ hosts:
             mode: active-backup
             options:
               miimon: "150"
-              primary: enp1s0f0
+              primary: enp1s0f0np0
             port:
-              - enp1s0f0
+              - enp1s0f0np0
               - enp6s0
-        - name: enp1s0f1
-          description: enp1s0f1
+        - name: enp1s0f1np1
+          description: enp1s0f1np1
           state: down
-        - name: enp1s0f2
-          description: enp1s0f2
+        - name: enp1s0f2np2
+          description: enp1s0f2np2
           state: down
-        - name: enp1s0f3
-          description: enp1s0f3
+        - name: enp1s0f3np3
+          description: enp1s0f3np3
           state: down
         - name: enp10s0
           description: enp10s0
@@ -155,13 +155,13 @@ hosts:
     rootDeviceHints:
       deviceName: "/dev/disk/by-path/pci-0000:02:00.1-ata-4.0"
     interfaces:
-      - name: enp1s0f0
+      - name: enp1s0f0np0
         macAddress: 98:b7:85:21:ed:e7
-      - name: enp1s0f1
+      - name: enp1s0f1np1
         macAddress: 98:b7:85:21:ed:e8
-      - name: enp1s0f2
+      - name: enp1s0f2np2
         macAddress: 98:b7:85:21:ed:e9
-      - name: enp1s0f3
+      - name: enp1s0f3np3
         macAddress: 98:b7:85:21:ed:ea
       - name: enp6s0
         macAddress: d8:07:b6:f8:1a:ef
@@ -190,18 +190,18 @@ hosts:
             mode: active-backup
             options:
               miimon: "150"
-              primary: enp1s0f0
+              primary: enp1s0f0np0
             port:
-              - enp1s0f0
+              - enp1s0f0np0
               - enp6s0
-        - name: enp1s0f1
-          description: enp1s0f1
+        - name: enp1s0f1np1
+          description: enp1s0f1np1
           state: down
-        - name: enp1s0f2
-          description: enp1s0f2
+        - name: enp1s0f2np2
+          description: enp1s0f2np2
           state: down
-        - name: enp1s0f3
-          description: enp1s0f3
+        - name: enp1s0f3np3
+          description: enp1s0f3np3
           state: down
         - name: enp6s0
           description: enp6s0


### PR DESCRIPTION
```bash
 sudo nmcli connection modify bond0 +bond.options "primary=enp1s0f0np0"
 ```
 ![Screenshot 2025-07-08 213047](https://github.com/user-attachments/assets/f69040fe-e824-4c62-a7b5-3e3ff3a38247)
![Screenshot 2025-07-08 213106](https://github.com/user-attachments/assets/6b90a6e4-9bcf-4794-b8db-b819b93746fc)
