### PR TITLE
chore(nextcloud): selinux relabel bypass disable

### DIFF
--- a/kubernetes/nextcloud/base/cronjob.yaml
+++ b/kubernetes/nextcloud/base/cronjob.yaml
@@ -22,10 +22,10 @@ spec:
           labels:
             app: nextcloud-cron
             db: nextcloud-pg
-          annotations:
-            io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"
+          # annotations:
+          #   io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"
         spec:
-          runtimeClassName: selinux
+          # runtimeClassName: selinux
           serviceAccountName: nextcloud-sa
           # affinity:
           #   podAffinity:

--- a/kubernetes/nextcloud/base/deployment.yaml
+++ b/kubernetes/nextcloud/base/deployment.yaml
@@ -24,9 +24,9 @@ spec:
         db: nextcloud-pg
       annotations:
         enable.version-checker.io/nextcloud: "true"
-        io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"
+        # io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"
     spec:
-      runtimeClassName: selinux
+      # runtimeClassName: selinux
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/kubernetes/nextcloud/base/preview-cronjob.yaml
+++ b/kubernetes/nextcloud/base/preview-cronjob.yaml
@@ -22,10 +22,10 @@ spec:
           labels:
             app: nextcloud-preview
             db: nextcloud-pg
-          annotations:
-            io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"
+          # annotations:
+          # io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"
         spec:
-          runtimeClassName: selinux
+          # runtimeClassName: selinux
           serviceAccountName: nextcloud-sa
           # affinity:
           #   podAffinity:

--- a/kubernetes/nextcloud/base/rsync-cronjob.yaml
+++ b/kubernetes/nextcloud/base/rsync-cronjob.yaml
@@ -21,10 +21,10 @@ spec:
         metadata:
           labels:
             app: nextcloud-rsync
-          annotations:
-            io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"
+          # annotations:
+          #   io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"
         spec:
-          runtimeClassName: selinux
+          # runtimeClassName: selinux
           serviceAccountName: nextcloud-sa
           # affinity:
           #   podAffinity:

--- a/kubernetes/nextcloud/overlays/sno/kustomization.yaml
+++ b/kubernetes/nextcloud/overlays/sno/kustomization.yaml
@@ -46,8 +46,8 @@ patches:
       kind: Dragonfly
       name: nextcloud-dragonfly
   - patch: |-
-      - op: remove
-        path: /spec/template/spec/runtimeClassName
+      # - op: remove
+      #   path: /spec/template/spec/runtimeClassName
       - op: replace
         path: /spec/replicas
         value: 1
@@ -64,11 +64,11 @@ patches:
     target:
       kind: CronJob
       name: nextcloud-rsync
-  - patch: |-
-      - op: remove
-        path: /spec/jobTemplate/spec/template/spec/runtimeClassName
-    target:
-      kind: CronJob
+  # - patch: |-
+  #     - op: remove
+  #       path: /spec/jobTemplate/spec/template/spec/runtimeClassName
+  #   target:
+  #     kind: CronJob
   - patch: |-
       apiVersion: policy/v1
       kind: PodDisruptionBudget

--- a/kubernetes/velero/base/kyverno.yaml
+++ b/kubernetes/velero/base/kyverno.yaml
@@ -1,32 +1,32 @@
-apiVersion: kyverno.io/v1
-kind: Policy
-metadata:
-  name: selinux
-  namespace: velero
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "1"
-spec:
-  background: false
-  rules:
-    - name: selinux
-      match:
-        any:
-          - resources:
-              kinds:
-                - Pod
-              selector:
-                matchLabels:
-                  velero.io/exposer-pod-group: snapshot-exposer
-      preconditions:
-        all:
-          - key: "{{ request.object.metadata.name }}"
-            operator: AnyIn
-            value: ["nextcloud*"]
-      mutate:
-        patchStrategicMerge:
-          metadata:
-            annotations:
-              io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"
-          spec:
-            runtimeClassName: selinux
+# apiVersion: kyverno.io/v1
+# kind: Policy
+# metadata:
+#   name: selinux
+#   namespace: velero
+#   annotations:
+#     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+#     argocd.argoproj.io/sync-wave: "1"
+# spec:
+#   background: false
+#   rules:
+#     - name: selinux
+#       match:
+#         any:
+#           - resources:
+#               kinds:
+#                 - Pod
+#               selector:
+#                 matchLabels:
+#                   velero.io/exposer-pod-group: snapshot-exposer
+#       preconditions:
+#         all:
+#           - key: "{{ request.object.metadata.name }}"
+#             operator: AnyIn
+#             value: ["nextcloud*"]
+#       mutate:
+#         patchStrategicMerge:
+#           metadata:
+#             annotations:
+#               io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"
+#           spec:
+#             runtimeClassName: selinux


### PR DESCRIPTION
Previously Required for RWX Ceph Pods with High File Counts

Issue still persists, but to a lesser extent