### PR TITLE
fix(clair-action): imagepullpolicy

### DIFF
--- a/tekton/base/clair-action/clair-action-task.yaml
+++ b/tekton/base/clair-action/clair-action-task.yaml
@@ -99,7 +99,7 @@ spec:
     - name: vuln-store
       image:
         reference: registry.arthurvardevanyan.com/homelab/clair-action-db:latest
-        pullPolicy: IfNotPresent
+        pullPolicy: Always
 
       # emptyDir:
       #   sizeLimit: 15Gi


### PR DESCRIPTION
## Problem
TaskRuns using the clair-action task were failing to start with:

## Root Cause
The vuln-store image volume was configured with pullPolicy: IfNotPresent. When the clair-action-db:latest image was already cached on the node, CRI-O skipped the pull and tracked the image internally by its bare digest (e.g. 5bf85942...). When the image volume mount attempted to resolve this artifact, it required a fully-qualified reference (registry.arthurvardevanyan.com/homelab/clair-action-db@sha256:5bf85942...) — a bare digest alone is not valid for image volume artifacts.

## Fix
Changed pullPolicy: IfNotPresent → Always on the vuln-store image volume. This ensures CRI-O always pulls the image and maintains a proper fully-qualified reference, allowing the image volume mount to resolve correctly.