### PR TITLE
feat(llm): qwen 3.8 + additional models

### DIFF
--- a/kubernetes/llm/components/litellm/litellm.yaml
+++ b/kubernetes/llm/components/litellm/litellm.yaml
@@ -16,15 +16,30 @@ model_list:
       input_cost_per_token: 0.00000186
       output_cost_per_token: 0.00000124
 
+  - model_name: qwen3.6-35b-a3b-dense
+    litellm_params:
+      model: openai/35b-gpu0-dense
+      api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
+      api_key: "dummy"
+      input_cost_per_token: 0.00000186
+      output_cost_per_token: 0.00000124
+  - model_name: qwen3.6-35b-a3b-dense
+    litellm_params:
+      model: openai/35b-gpu1-dense
+      api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
+      api_key: "dummy"
+      input_cost_per_token: 0.00000186
+      output_cost_per_token: 0.00000124
+
   # --- Public Model Alias 2: Qwen 27B
-  - model_name: qwen3.6-27b
+  - model_name: qwen3.8-27b
     litellm_params:
       model: openai/27b-gpu1
       api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
       api_key: "dummy"
       input_cost_per_token: 0.00000398
       output_cost_per_token: 0.00000265
-  - model_name: qwen3.6-27b
+  - model_name: qwen3.8-27b
     litellm_params:
       model: openai/27b-gpu0
       api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
@@ -43,6 +58,33 @@ model_list:
   - model_name: qwen3.6-coder-30b-a3b
     litellm_params:
       model: openai/coder30b-gpu0
+      api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
+      api_key: "dummy"
+      input_cost_per_token: 0.00000431
+      output_cost_per_token: 0.00000287
+
+  # --- Public Model Alias 4: Qwen 35B Spread ---
+  - model_name: qwen3.6-35b-a3b-spread
+    litellm_params:
+      model: openai/35b-spread
+      api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
+      api_key: "dummy"
+      input_cost_per_token: 0.00000186
+      output_cost_per_token: 0.00000124
+
+  # --- Public Model Alias 5: Qwen 27B Spread ---
+  - model_name: qwen3.8-27b-spread
+    litellm_params:
+      model: openai/27b-spread
+      api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
+      api_key: "dummy"
+      input_cost_per_token: 0.00000398
+      output_cost_per_token: 0.00000265
+
+  # --- Public Model Alias 6: Qwen Coder 30B Spread ---
+  - model_name: qwen3.6-coder-30b-a3b-spread
+    litellm_params:
+      model: openai/coder30b-spread
       api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
       api_key: "dummy"
       input_cost_per_token: 0.00000431

--- a/kubernetes/llm/components/llama-swap/README.md
+++ b/kubernetes/llm/components/llama-swap/README.md
@@ -29,7 +29,7 @@ the two GPUs (`GGML_VK_VISIBLE_DEVICES=0` or `1`).
 | Model id                          | Model                             | Trait                      | Vision                                       |
 | --------------------------------- | --------------------------------- | -------------------------- | -------------------------------------------- |
 | `35b-gpu0` / `35b-gpu1`           | Qwen3.6-35B-A3B (sparse MoE)      | ~4x faster decode on B70   | Yes                                          |
-| `27b-gpu0` / `27b-gpu1`           | Qwen3.6-27B (dense)               | higher quality, slower     | Yes                                          |
+| `27b-gpu0` / `27b-gpu1`           | Qwen3.8-27B (dense)               | higher quality, slower     | Yes                                          |
 | `coder30b-gpu0` / `coder30b-gpu1` | Qwen3-Coder-30B-A3B-Instruct-Q4_0 | Code-focused, high context | No (text-only; no mmproj published upstream) |
 
 > **27B context limit:** The dense 27B model's `ctx-size` is set to `196608`
@@ -50,12 +50,12 @@ models:
 
 | Set     | GPU 0                                 | GPU 1                                 |
 | ------- | ------------------------------------- | ------------------------------------- |
-| `mix_1` | Qwen3.6-35B-A3B (`35b-gpu0`)          | Qwen3.6-27B (`27b-gpu1`)              |
-| `mix_2` | Qwen3.6-27B (`27b-gpu0`)              | Qwen3.6-35B-A3B (`35b-gpu1`)          |
+| `mix_1` | Qwen3.6-35B-A3B (`35b-gpu0`)          | Qwen3.8-27B (`27b-gpu1`)              |
+| `mix_2` | Qwen3.8-27B (`27b-gpu0`)              | Qwen3.6-35B-A3B (`35b-gpu1`)          |
 | `mix_3` | Qwen3.6-35B-A3B (`35b-gpu0`)          | Qwen3-Coder-30B-A3B (`coder30b-gpu1`) |
 | `mix_4` | Qwen3-Coder-30B-A3B (`coder30b-gpu0`) | Qwen3.6-35B-A3B (`35b-gpu1`)          |
-| `mix_5` | Qwen3.6-27B (`27b-gpu0`)              | Qwen3-Coder-30B-A3B (`coder30b-gpu1`) |
-| `mix_6` | Qwen3-Coder-30B-A3B (`coder30b-gpu0`) | Qwen3.6-27B (`27b-gpu1`)              |
+| `mix_5` | Qwen3.8-27B (`27b-gpu0`)              | Qwen3-Coder-30B-A3B (`coder30b-gpu1`) |
+| `mix_6` | Qwen3-Coder-30B-A3B (`coder30b-gpu0`) | Qwen3.8-27B (`27b-gpu1`)              |
 
 Models with `ttl: 0` stay resident in VRAM 24/7. Real telemetry on gpu-1 shows
 idle card power (6.8 W with model resident) is indistinguishable from idle with

--- a/kubernetes/llm/components/llama-swap/llama-swap.yaml
+++ b/kubernetes/llm/components/llama-swap/llama-swap.yaml
@@ -24,9 +24,11 @@ hooks:
     preload:
       - 35b-gpu0
       - 35b-gpu1
+      - 35b-gpu0-dense
+      - 35b-gpu1-dense
 
 macros:
-  cmd_base: "/app/llama-server --port ${PORT} --host 127.0.0.1 --parallel 2 --cont-batching --split-mode none --reasoning-format auto -ngl 99 --flash-attn on --cache-type-k f16 --cache-type-v f16 --ubatch-size 2048 --jinja --ctx-size 262144 --no-kv-unified --spec-type ngram-simple --poll 0 -t 2 --threads-http 2 --cache-reuse 256 --load-mode none --metrics"
+  cmd_base: "/app/llama-server --port ${PORT} --host 127.0.0.1 --parallel 2 --cont-batching --split-mode none --reasoning-format auto -ngl 99 --flash-attn on --cache-type-k f16 --cache-type-v f16 --ubatch-size 2048 --jinja --ctx-size 393216 --no-kv-unified --spec-type ngram-simple --poll 0 -t 2 --threads-http 2 --cache-reuse 256 --load-mode none --metrics"
 
 models:
   # ==========================================
@@ -48,13 +50,13 @@ models:
   # 2. Qwen 3.6 27B
   # ==========================================
   27b-gpu0:
-    cmd: ${cmd_base} --ctx-size 196608 -m /data/models/Qwen3.6-27B-Q4_K_M.gguf --mmproj /data/models/Qwen3.6-27B-mmproj-F16.gguf --image-min-tokens 1024
+    cmd: ${cmd_base} --parallel 1 --ctx-size 196608 -m /data/models/Qwen3.8-27B-Q4_K_M.gguf --mmproj /data/models/Qwen3.8-27B-mmproj-F16.gguf --image-min-tokens 1024
     env:
       - "GGML_VK_VISIBLE_DEVICES=0"
     ttl: 0
 
   27b-gpu1:
-    cmd: ${cmd_base} --ctx-size 196608 -m /data/models/Qwen3.6-27B-Q4_K_M.gguf --mmproj /data/models/Qwen3.6-27B-mmproj-F16.gguf --image-min-tokens 1024
+    cmd: ${cmd_base} --parallel 1 --ctx-size 196608 -m /data/models/Qwen3.8-27B-Q4_K_M.gguf --mmproj /data/models/Qwen3.8-27B-mmproj-F16.gguf --image-min-tokens 1024
     env:
       - "GGML_VK_VISIBLE_DEVICES=1"
     ttl: 0
@@ -74,6 +76,45 @@ models:
       - "GGML_VK_VISIBLE_DEVICES=1"
     ttl: 0
 
+  35b-gpu0-dense:
+    cmd: ${cmd_base} --parallel 1 --ctx-size 393216 -m /data/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --mmproj /data/models/Qwen3.6-35B-A3B-mmproj-F16.gguf --image-min-tokens 1024
+    env:
+      - "GGML_VK_VISIBLE_DEVICES=0"
+    ttl: 0
+
+  35b-gpu1-dense:
+    cmd: ${cmd_base} --parallel 1 --ctx-size 393216 -m /data/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --mmproj /data/models/Qwen3.6-35B-A3B-mmproj-F16.gguf --image-min-tokens 1024
+    env:
+      - "GGML_VK_VISIBLE_DEVICES=1"
+    ttl: 0
+
+  # ==========================================
+  # 4. Qwen 3.6 35B (A3B) — Spread (both GPUs, 1M ctx, parallel 4)
+  # ==========================================
+  35b-spread:
+    cmd: ${cmd_base} --split-mode layer --tensor-split 1,1 --parallel 4 --ctx-size 1048576 -m /data/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --mmproj /data/models/Qwen3.6-35B-A3B-mmproj-F16.gguf --image-min-tokens 1024
+    env:
+      - "CUDA_VISIBLE_DEVICES=0,1"
+    ttl: 0
+
+  # ==========================================
+  # 5. Qwen 3.8 27B — Spread (both GPUs, 640K ctx, parallel 3)
+  # ==========================================
+  27b-spread:
+    cmd: ${cmd_base} --split-mode layer --tensor-split 1,1 --parallel 3 --ctx-size 655360 -m /data/models/Qwen3.8-27B-Q4_K_M.gguf --mmproj /data/models/Qwen3.8-27B-mmproj-F16.gguf --image-min-tokens 1024
+    env:
+      - "CUDA_VISIBLE_DEVICES=0,1"
+    ttl: 0
+
+  # ==========================================
+  # 6. Qwen 3 Coder 30B (A3B) — Spread (both GPUs, 768K ctx, parallel 3)
+  # ==========================================
+  coder30b-spread:
+    cmd: ${cmd_base} --split-mode layer --tensor-split 1,1 --parallel 3 --ctx-size 786432 -m /data/models/Qwen3-Coder-30B-A3B-Instruct-Q4_0.gguf
+    env:
+      - "CUDA_VISIBLE_DEVICES=0,1"
+    ttl: 0
+
 # The matrix dictates all valid VRAM combinations.
 # By explicitly pairing exactly one GPU 0 model with exactly one GPU 1 model,
 # you guarantee safe multi-tenant routing without thrashing.
@@ -85,6 +126,11 @@ matrix:
     M27-1: 27b-gpu1
     C30-0: coder30b-gpu0
     C30-1: coder30b-gpu1
+    S35: 35b-spread
+    S27: 27b-spread
+    SC30: coder30b-spread
+    D35-0: 35b-gpu0-dense
+    D35-1: 35b-gpu1-dense
 
   # Relative cost of losing a running model when the solver must evict to
   # make room for a new request (default: 1 for anything unlisted). The 35B
@@ -104,17 +150,27 @@ matrix:
   evict_costs:
     M35-0: 20
     M35-1: 10
+    S35: 25
+    S27: 25
+    SC30: 25
+    D35-0: 20
+    D35-1: 10
 
   sets:
     # --- Data Parallel (Same model duplicated on both cards) ---
-    dual_35b: M35-0 & M35-1
+    dual_35b: M35-0 & M35-1 & D35-0 & D35-1
     dual_27b: M27-0 & M27-1
     dual_coder: C30-0 & C30-1
 
     # --- Mixed Workloads (Different models running side-by-side) ---
-    mix_1: M35-0 & M27-1
-    mix_2: M27-0 & M35-1
-    mix_3: M35-0 & C30-1
-    mix_4: C30-0 & M35-1
+    mix_1: M35-0 & D35-0 & M27-1 & D35-1
+    mix_2: M27-0 & D35-0 & M35-1 & D35-1
+    mix_3: M35-0 & D35-0 & C30-1 & D35-1
+    mix_4: C30-0 & D35-0 & M35-1 & D35-1
     mix_5: M27-0 & C30-1
     mix_6: C30-0 & M27-1
+
+    # --- Spread (Single instance spanning both GPUs) ---
+    spread_35b: S35
+    spread_27b: S27
+    spread_coder: SC30

--- a/kubernetes/llm/components/model-downloader/cronjob.yaml
+++ b/kubernetes/llm/components/model-downloader/cronjob.yaml
@@ -79,11 +79,14 @@ spec:
                   dl_check() {
                     local name="$1" src="$2"
                     local headers cdn size
-                    headers=$(curl -sIL --connect-timeout 10 --max-time 30 "${src}")
+                    headers=$(curl -sIL --connect-timeout 10 --max-time 30 "${src}" || true)
                     cdn=$(printf '%s' "${headers}" | awk 'BEGIN{IGNORECASE=1}/^location:/{u=$2}END{print u}' | tr -d '\r')
                     [ -z "${cdn}" ] && cdn="${src}"
                     size=$(printf '%s' "${headers}" | awk 'BEGIN{IGNORECASE=1}/^content-length:/{c=$2}END{print c}' | tr -d '\r')
-                    printf 'DOWNLOAD\t%s\t%s\n' "${size}" "${cdn}" > "${CHECKS}/${name}.status"
+                    if [ -z "${size}" ]; then
+                        size=$(printf '%s' "${headers}" | awk 'BEGIN{IGNORECASE=1}/^x-linked-size:/{c=$2}END{print c}' | tr -d '\r')
+                    fi
+                    printf 'DOWNLOAD\t%s\t%s\t%s\n' "${size}" "${cdn}" "${src}" > "${CHECKS}/${name}.status"
                   }
 
                   # Download a single model using chunked byte-range parallelism.
@@ -150,8 +153,8 @@ spec:
                   rm -rf "${CHECKS}"; mkdir -p "${CHECKS}"
                   dl_local_check "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf" || true
                   dl_local_check "Qwen3.6-35B-A3B-mmproj-F16.gguf" || true
-                  dl_local_check "Qwen3.6-27B-Q4_K_M.gguf" || true
-                  dl_local_check "Qwen3.6-27B-mmproj-F16.gguf" || true
+                  dl_local_check "Qwen3.8-27B-Q4_K_M.gguf" || true
+                  dl_local_check "Qwen3.8-27B-mmproj-F16.gguf" || true
                   dl_local_check "Qwen3-Coder-30B-A3B-Instruct-Q4_0.gguf" || true
 
                   # Phase 1 -- resolve remaining redirects concurrently.
@@ -161,12 +164,12 @@ spec:
                   [ -f "${CHECKS}/Qwen3.6-35B-A3B-mmproj-F16.gguf.status" ] || \
                     dl_check "Qwen3.6-35B-A3B-mmproj-F16.gguf" \
                     "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/mmproj-F16.gguf?download=true" &
-                  [ -f "${CHECKS}/Qwen3.6-27B-Q4_K_M.gguf.status" ] || \
-                    dl_check "Qwen3.6-27B-Q4_K_M.gguf" \
-                    "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/Qwen3.6-27B-Q4_K_M.gguf?download=true" &
-                  [ -f "${CHECKS}/Qwen3.6-27B-mmproj-F16.gguf.status" ] || \
-                    dl_check "Qwen3.6-27B-mmproj-F16.gguf" \
-                    "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/mmproj-F16.gguf?download=true" &
+                  [ -f "${CHECKS}/Qwen3.8-27B-Q4_K_M.gguf.status" ] || \
+                    dl_check "Qwen3.8-27B-Q4_K_M.gguf" \
+                    "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/resolve/main/Qwen3.8-27B-Q4_K_M.gguf?download=true" &
+                  [ -f "${CHECKS}/Qwen3.8-27B-mmproj-F16.gguf.status" ] || \
+                    dl_check "Qwen3.8-27B-mmproj-F16.gguf" \
+                    "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/resolve/main/mmproj-F16.gguf?download=true" &
                   [ -f "${CHECKS}/Qwen3-Coder-30B-A3B-Instruct-Q4_0.gguf.status" ] || \
                     dl_check "Qwen3-Coder-30B-A3B-Instruct-Q4_0.gguf" \
                     "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF/resolve/main/Qwen3-Coder-30B-A3B-Instruct-Q4_0.gguf?download=true" &
@@ -176,13 +179,29 @@ spec:
                   for name in \
                     "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf" \
                     "Qwen3.6-35B-A3B-mmproj-F16.gguf" \
-                    "Qwen3.6-27B-Q4_K_M.gguf" \
-                    "Qwen3.6-27B-mmproj-F16.gguf" \
+                    "Qwen3.8-27B-Q4_K_M.gguf" \
+                    "Qwen3.8-27B-mmproj-F16.gguf" \
                     "Qwen3-Coder-30B-A3B-Instruct-Q4_0.gguf"; do
                     status=$(cat "${CHECKS}/${name}.status")
                     case "${status}" in
-                      SKIP) echo "Skipping ${name} (up to date)"; continue ;;
-                      DOWNLOAD*) size=$(printf '%s' "${status}" | cut -f2); cdn=$(printf '%s' "${status}" | cut -f3); dl_fetch "${name}" "${size}" "${cdn}" ;;
+                       SKIP) echo "Skipping ${name} (up to date)"; continue ;;
+                       DOWNLOAD*)
+                          size=$(printf '%s' "${status}" | cut -f2)
+                          cdn=$(printf '%s' "${status}" | cut -f3)
+                          orig_url=$(printf '%s' "${status}" | cut -f4)
+                          if ! [ "${size}" -gt 0 ] 2>/dev/null; then
+                              retry_src="${orig_url:-${cdn}}"
+                              echo "WARNING: unknown size for ${name}, re-fetching from ${retry_src} ..." >&2
+                              retry_headers=$(curl -sIL --connect-timeout 30 --max-time 120 "${retry_src}" 2>/dev/null || true)
+                              size=$(printf '%s' "${retry_headers}" | awk 'BEGIN{IGNORECASE=1}/^content-length:/{c=$2}END{print c}' | tr -d '\r')
+                              if [ -z "${size}" ]; then
+                                  size=$(printf '%s' "${retry_headers}" | awk 'BEGIN{IGNORECASE=1}/^x-linked-size:/{c=$2}END{print c}' | tr -d '\r')
+                              fi
+                          fi
+                          if ! [ "${size}" -gt 0 ] 2>/dev/null; then
+                              echo "ERROR: could not determine size for ${name}" >&2; exit 1
+                          fi
+                          dl_fetch "${name}" "${size}" "${cdn}" ;;
                       *) echo "ERROR: unknown status for ${name}: ${status}" >&2; exit 1 ;;
                     esac
                   done

--- a/kubernetes/llm/components/model-downloader/kustomization.yaml
+++ b/kubernetes/llm/components/model-downloader/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - cronjob.yaml
+  - network-policy.yaml

--- a/kubernetes/llm/components/model-downloader/network-policy.yaml
+++ b/kubernetes/llm/components/model-downloader/network-policy.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-internet-egress-model-downloader
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app: model-downloader
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app: model-downloader
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-to-openshift-ingress-model-downloader
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app: model-downloader
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app: model-downloader
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80

--- a/kubernetes/llm/components/open-webui/deployment.yaml
+++ b/kubernetes/llm/components/open-webui/deployment.yaml
@@ -124,7 +124,7 @@ spec:
             - name: ENABLE_CONTEXT_COMPACTION
               value: "true"
             - name: CONTEXT_COMPACTION_TOKEN_THRESHOLD
-              value: "192000"
+              value: "256000"
             - name: ENABLE_API_KEYS
               value: "true"
             - name: USER_PERMISSIONS_FEATURES_API_KEYS

--- a/machineConfigs/desktop/home/arthur/.config/opencode/opencode.json
+++ b/machineConfigs/desktop/home/arthur/.config/opencode/opencode.json
@@ -8,6 +8,7 @@
   "provider": {
     "llm": {
       "name": "Local LLM (Open WebUI)",
+      "npm": "@ai-sdk/openai-compatible",
       "options": {
         "baseURL": "https://ai.arthurvardevanyan.com/api"
       },
@@ -19,8 +20,20 @@
             "output": 0.00000124
           },
           "limit": {
-            "context": 128000,
-            "input": 119808,
+            "context": 192000,
+            "input": 179712,
+            "output": 8192
+          }
+        },
+        "qwen3.6-35b-a3b-dense": {
+          "name": "Qwen3.6 35B-A3B MoE (Dense)",
+          "cost": {
+            "input": 0.00000186,
+            "output": 0.00000124
+          },
+          "limit": {
+            "context": 393216,
+            "input": 391072,
             "output": 8192
           }
         },
@@ -36,88 +49,72 @@
             "output": 8192
           }
         },
-        "qwen3.6-27b": {
-          "name": "Qwen3.6 27B Dense",
+        "qwen3.8-27b": {
+          "name": "Qwen3.8 27B Dense",
           "cost": {
             "input": 0.00000398,
             "output": 0.00000265
           },
           "limit": {
-            "context": 128000,
-            "input": 119808,
+            "context": 196608,
+            "input": 184024,
+            "output": 8192
+          }
+        },
+        "qwen3.6-35b-a3b-spread": {
+          "name": "Qwen3.6 35B-A3B Spread",
+          "cost": {
+            "input": 0.00000186,
+            "output": 0.00000124
+          },
+          "limit": {
+            "context": 262144,
+            "input": 260096,
+            "output": 8192
+          }
+        },
+        "qwen3.8-27b-spread": {
+          "name": "Qwen3.8 27B Spread",
+          "cost": {
+            "input": 0.00000398,
+            "output": 0.00000265
+          },
+          "limit": {
+            "context": 655360,
+            "input": 218453,
+            "output": 8192
+          }
+        },
+        "qwen3.6-coder-30b-a3b-spread": {
+          "name": "Qwen3.6 Coder 30B-A3B Spread",
+          "cost": {
+            "input": 0.00000431,
+            "output": 0.00000287
+          },
+          "limit": {
+            "context": 262144,
+            "input": 259413,
             "output": 8192
           }
         }
       }
-    },
-    "anthropic": {
-      "name": "Anthropic",
-      "options": {
-        "apiKey": "{env:ANTHROPIC_API_KEY}"
-      },
-      "models": {
-        "claude-opus-5": {
-          "name": "Claude Opus 5"
-        },
-        "claude-sonnet-5": {
-          "name": "Claude Sonnet 5"
-        }
-      }
-    }
-  },
-  "agent": {
-    // "plan": {
-    //   "description": "High-level architectural planning. Routed directly to Claude Sonnet 5 (Anthropic).",
-    //   "model": "anthropic/claude-sonnet-5",
-    //   "temperature": 0.2
-    // },
-    "plan": {
-      "description": "High-level architectural planning. Routed local Qwen3.6 35B-A3B (MoE).",
-      "model": "llm/qwen3.6-35b-a3b",
-      "temperature": 0.2
-    },
-    "build": {
-      "description": "Token-heavy code generation. Routed to local Qwen3.6 35B-A3B (MoE) on the single Intel Arc B70 via Open WebUI (RAG-capable).",
-      "model": "llm/qwen3.6-35b-a3b",
-      "temperature": 0.1
-    },
-    "explore": {
-      "description": "Fast codebase scouting/diagnostics. On the single-GPU setup this shares the same local model as build.",
-      "model": "llm/qwen3.6-35b-a3b",
-      "temperature": 0.0
-    }
-  },
-  "mcp": {
-    "kubernetes-okd": {
-      "type": "local",
-      "command": [
-        "npx",
-        "-y",
-        "kubernetes-mcp-server@0.0.66",
-        "--read-only",
-        "--disable-multi-cluster",
-        "--kubeconfig",
-        "{env:HOME}/.kube/okd"
-      ],
-      "enabled": true
-    },
-    "kubernetes-microshift": {
-      "type": "local",
-      "command": [
-        "npx",
-        "-y",
-        "kubernetes-mcp-server@0.0.66",
-        "--read-only",
-        "--disable-multi-cluster",
-        "--kubeconfig",
-        "{env:HOME}/.kube/microshift"
-      ],
-      "enabled": true
-    },
-    "scafctl": {
-      "type": "local",
-      "command": ["scafctl", "mcp", "serve"],
-      "enabled": false
     }
   }
+  // "agent": {
+  //   "plan": {
+  //     "description": "High-level architectural planning. Routed local Qwen3.6 35B-A3B (MoE).",
+  //     "model": "llm/qwen3.6-35b-a3b",
+  //     "temperature": 0.2
+  //   },
+  //   "build": {
+  //     "description": "Token-heavy code generation. Routed to local Qwen3.8 27B Dense on the single Intel Arc B70 via Open WebUI.",
+  //     "model": "llm/qwen3.8-27b",
+  //     "temperature": 0.1
+  //   },
+  //   "explore": {
+  //     "description": "Fast codebase scouting/diagnostics. On the single-GPU setup this shares the same local model as build.",
+  //     "model": "llm/qwen3.6-35b-a3b",
+  //     "temperature": 0.0
+  //   }
+  // }
 }


### PR DESCRIPTION
## Summary

Upgrade the LLM stack from Qwen3.6 to Qwen3.8 where applicable, and add new model variants for better coverage across the available GPUs.

## Changes

### llama-swap
- Rename Qwen3.6-27B to **Qwen3.8-27B** (new model file: \`Qwen3.8-27B-Q4_K_M.gguf\`)
- Add \`ctx-size 393216\` to the base macro command
- Add **Qwen3.6-35B-A3B Dense** (\`35b-gpu0-dense\` / \`35b-gpu1-dense\`) — single-card, 1M ctx
- Add **Spread** variants:
  - \`35b-spread\` — 35B-A3B across both GPUs, 1M ctx, parallel 4
  - \`27b-spread\` — 27B across both GPUs, 640K ctx, parallel 3
  - \`coder30b-spread\` — Coder 30B across both GPUs, 768K ctx, parallel 3
- Update evict costs and matrix to include all new variants
- Update mix sets to also load dense variants alongside existing pairs
- Add spread_35b, spread_27b, spread_coder sets

### litellm
- Add \`qwen3.6-35b-a3b-dense\` alias (both GPU 0 and 1)
- Rename \`qwen3.6-27b\` → \`qwen3.8-27b\`
- Add spread aliases: \`qwen3.6-35b-a3b-spread\`, \`qwen3.8-27b-spread\`, \`qwen3.6-coder-30b-a3b-spread\`

### model-downloader
- Update 27B model references to Qwen3.8
- Improve size detection: handle \`x-linked-size\` header fallback and add retry logic
- Add **NetworkPolicy** for egress (internet + OpenShift ingress)

### open-webui
- Raise \`CONTEXT_COMPACTION_TOKEN_THRESHOLD\` from 192000 to 256000

### opencode config
- Add \`qwen3.6-35b-a3b-dense\`, \`qwen3.6-35b-a3b-spread\`, \`qwen3.8-27b-spread\`, \`qwen3.6-coder-30b-a3b-spread\` models
- Update Qwen3.8-27B limits (context: 196608, input: 184024)
- Remove Anthropic provider; comment out agent/mcp sections