### PR TITLE
feat(litellm): add session stickiness for KV cache reuse

### DIFF
--- a/kubernetes/grafana/base/dashboards/llama-swap.json
+++ b/kubernetes/grafana/base/dashboards/llama-swap.json
@@ -1958,7 +1958,73 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "rate(llamacpp:tokens_predicted_total[interval]) / rate(llamacpp:n_decode_total[interval])",
+      "description": "Estimated KV cache hit ratio: 1 - (llamacpp prompt tokens / LiteLLM input tokens). Approximation because LiteLLM counts all API input tokens including system messages.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 59
+      },
+      "id": 214,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "openInEditor": false,
+        "text": {
+          "valueSize": 48
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "100 * (1 - rate(llamacpp:prompt_tokens_total{model=~\"$model\"}[5m]) / rate(litellm_input_tokens_metric_total{model=~\"$model\"}[5m]))",
+          "legendFormat": "{{model}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "KV Cache Hit Ratio %",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "KV cache hit ratio over time. Higher = more tokens served from KV cache.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1968,11 +2034,110 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "tokens/decode",
+            "axisLabel": "%",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 59
+      },
+      "id": 215,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "mean"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "100 * (1 - rate(llamacpp:prompt_tokens_total{model=~\"$model\"}[5m]) / rate(litellm_input_tokens_metric_total{model=~\"$model\"}[5m]))",
+          "legendFormat": "{{model}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "KV Cache Hit Ratio Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Estimated tokens served from KV cache per second: input_tokens - prompt_tokens_processed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "tokens/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "draw_style": "line",
             "fillOpacity": 15,
             "gradientMode": "none",
             "hideFrom": {
@@ -2004,7 +2169,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": 0
+                "value": null
               }
             ]
           }
@@ -2012,201 +2177,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 0,
-        "y": 59
-      },
-      "id": 214,
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull", "mean", "max"],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "rate(llamacpp:tokens_predicted_total{model=~\"$model\"}[$__rate_interval]) / rate(llamacpp:n_decode_total{model=~\"$model\"}[$__rate_interval])",
-          "legendFormat": "{{model}} Tokens per decode",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Tokens per Decode",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "rate(llamacpp:n_decode_total[interval])",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "calls/s",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 15,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "ops/sec"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 6,
-        "y": 59
-      },
-      "id": 215,
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull", "mean", "max"],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "rate(llamacpp:n_decode_total{model=~\"$model\"}[$__rate_interval])",
-          "legendFormat": "{{model}} Decode calls",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Decode Calls/sec",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "1000 * rate(llamacpp:prompt_seconds_total[interval]) / rate(llamacpp:prompt_tokens_total[interval])",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "ms/token",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 15,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 12,
+        "h": 4,
+        "w": 8,
+        "x": 16,
         "y": 59
       },
       "id": 216,
@@ -2223,7 +2196,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -2231,13 +2203,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "1000 * rate(llamacpp:prompt_seconds_total{model=~\"$model\"}[$__rate_interval]) / rate(llamacpp:prompt_tokens_total{model=~\"$model\"}[$__rate_interval])",
-          "legendFormat": "{{model}} Prompt latency/token",
+          "expr": "rate(litellm_input_tokens_metric_total{model=~\"$model\"}[5m]) - rate(llamacpp:prompt_tokens_total{model=~\"$model\"}[5m])",
+          "legendFormat": "{{model}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Prompt Latency",
+      "title": "KV Cache Reused Tokens",
       "type": "timeseries"
     },
     {
@@ -2245,7 +2217,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "1000 * rate(llamacpp:tokens_predicted_seconds_total[interval]) / rate(llamacpp:tokens_predicted_total[interval])",
+      "description": "Ratio of llama.cpp prompt tokens to LiteLLM input tokens. Lower ratio = more cache reuse (tokens not re-processed by model).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2255,7 +2227,7 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "ms/token",
+            "axisLabel": "ratio",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "barWidthFactor": 0.6,
@@ -2291,24 +2263,23 @@
             "steps": [
               {
                 "color": "green",
-                "value": 0
+                "value": null
               }
             ]
-          },
-          "unit": "ms"
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 18,
-        "y": 59
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 63
       },
       "id": 217,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "mean", "max"],
+          "calcs": ["lastNotNull", "mean"],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -2319,7 +2290,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -2327,13 +2297,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "1000 * rate(llamacpp:tokens_predicted_seconds_total{model=~\"$model\"}[$__rate_interval]) / rate(llamacpp:tokens_predicted_total{model=~\"$model\"}[$__rate_interval])",
-          "legendFormat": "{{model}} Generation latency/token",
+          "expr": "rate(llamacpp:prompt_tokens_total{model=~\"$model\"}[5m]) / rate(litellm_input_tokens_metric_total{model=~\"$model\"}[5m])",
+          "legendFormat": "{{model}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Generation Latency",
+      "title": "Prompt Processing Ratio",
       "type": "timeseries"
     },
     {
@@ -3517,5 +3487,5 @@
   "timezone": "",
   "title": "llama-swap",
   "uid": "llama-swap",
-  "version": 4
+  "version": 5
 }

--- a/kubernetes/llm/components/litellm/README.md
+++ b/kubernetes/llm/components/litellm/README.md
@@ -111,11 +111,22 @@ candidate list using llama-swap's ground truth:
 2. **One resident**: narrow to it. Every model runs with `ttl: 0` (never expires),
    so if only one copy is loaded, the other GPU is almost certainly serving a
    different model — routing there would force an unnecessary eviction.
-3. **Both ready**: poll llama.cpp's per-instance `/slots` endpoint (proxied
-   through `llama-swap-svc:8080/upstream/<model>/slots`) for actual busy-slot
-   counts, route to whichever has fewer busy slots. Ties are broken with a
-   round-robin counter — this is what fixes the observed skew where LiteLLM's
-   built-in counter always chose the first-listed deployment.
+3. **Both ready**: check for session stickiness first, then fall back to
+   least-busy slot selection:
+
+   - **Session stickiness**: the plugin computes a sha256 fingerprint from the
+     model name and the first user message content (truncated to 500 chars), then
+     looks up an in-memory pin map. If a valid pin (not expired, 1h TTL) exists
+     and the pinned GPU is ready, the request is routed there to keep the
+     conversation's KV cache hot. If the pinned GPU is not ready, it falls back
+     to least-busy and creates a new pin. The pin map has an LRU eviction cap of
+     10,000 entries.
+
+   - **Least-busy**: when no pin applies, poll llama.cpp's per-instance `/slots`
+     endpoint (proxied through `llama-swap-svc:8080/upstream/<model>/slots`) for
+     actual busy-slot counts, route to whichever has fewer busy slots. Ties are
+     broken with a round-robin counter — this is what fixes the observed skew
+     where LiteLLM's built-in counter always chose the first-listed deployment.
 
 The plugin caches `/running` (1s TTL) and `/slots` (0.25s TTL) to avoid
 hammering llama-swap during request bursts. HTTP calls use a 1s timeout; on
@@ -125,6 +136,28 @@ hiccup never blocks routing.
 The `/slots` poll is proxied through llama-swap's `upstream.ignorePaths` guard
 (see `llama-swap.yaml`) which prevents the path from ever triggering a model
 load/swap — defense-in-depth against a bug in the plugin doing otherwise.
+
+#### KV cache efficiency
+
+Session stickiness preserves llama.cpp's per-instance KV cache across consecutive
+turns in the same conversation. Without it, the round-robin tie-break caused each
+turn to alternate GPUs, evicting and rebuilding the KV cache on every request.
+
+The llama-swap Grafana dashboard's **Efficiency** row now includes panels for:
+
+- **KV Cache Hit Ratio %**: estimated as `1 - (llamacpp:prompt_tokens_total /
+litellm_input_tokens_metric_total)` — the fraction of input tokens served from
+  KV cache rather than re-processed by the model.
+- **KV Cache Reused Tokens**: estimated rate of tokens served from cache
+  (input_tokens − prompt_tokens_processed).
+- **Prompt Processing Ratio**: ratio of llama.cpp prompt tokens to LiteLLM input
+  tokens. A lower ratio indicates more cache reuse.
+
+Note: these are estimates because LiteLLM counts all API input tokens
+(system messages, tool calls, etc.) while llama.cpp only counts tokens actually
+processed by the model. Direct `cached_tokens` metrics from llama.cpp's
+`usage.prompt_tokens_details.cached_tokens` are not exposed via the
+llama-cpp-exporter's Prometheus metrics endpoint.
 
 ## Deployment
 

--- a/kubernetes/llm/components/litellm/llama_swap_affinity.py
+++ b/kubernetes/llm/components/litellm/llama_swap_affinity.py
@@ -67,6 +67,7 @@ disabled globally.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import os
 import time
 from typing import Final
@@ -102,6 +103,13 @@ _SLOTS_CACHE_TTL_SECONDS: Final = 0.25
 # far as residency data allows) so a llama-swap hiccup never blocks routing.
 _REQUEST_TIMEOUT_SECONDS: Final = 1.0
 
+# Session-stickiness: content-fingerprint pin map.
+# Maps sha256(fingerprint) -> (deployment_model, expiry_timestamp).
+# TTL of 1h balances KV-cache retention against memory churn when models
+# rotate frequently. Cap of 10k pins prevents unbounded growth.
+_PIN_TTL_SECONDS: Final = 3600.0
+_PIN_MAP_MAX: Final = 10000
+
 
 def _strip_provider_prefix(model: str) -> str:
     """`openai/35b-gpu0` -> `35b-gpu0` to match llama-swap's model IDs."""
@@ -118,6 +126,9 @@ class LlamaSwapAffinityPlugin:
         self._running_cache_expires_at: float = 0.0
         self._slots_cache: dict[str, tuple[int, float]] = {}
         self._round_robin_counter: int = 0
+        # Session-stickiness pin map: fingerprint -> (deployment_model, expiry)
+        self._pin_map: dict[str, tuple[str, float]] = {}
+        self._pin_order: list[str] = []  # LRU tracking (insertion order)
 
     def _get_client(self) -> httpx.AsyncClient:
         # Built lazily inside `run()`, never at import time: this module is
@@ -188,6 +199,84 @@ class LlamaSwapAffinityPlugin:
         self._round_robin_counter += 1
         return winner
 
+    def _compute_fingerprint(self, context: RoutingContext) -> str | None:
+        """Compute a sha256 fingerprint for session stickiness.
+
+        Uses the model name and the content of the first user message.
+        Truncated to 500 chars to keep the fingerprint deterministic but
+        bounded. Returns None if no user message can be found.
+        """
+        if not context.structured_messages:
+            return None
+
+        for msg in context.structured_messages:
+            if msg.get("role") != "user":
+                continue
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                text = content[:500]
+            elif isinstance(content, list):
+                # OpenAI multi-modal format: extract text blocks
+                text_parts = [
+                    block.get("text", "")
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "text"
+                ]
+                text = " ".join(text_parts)[:500]
+            else:
+                text = str(content)[:500]
+
+            if not text.strip():
+                continue
+
+            # Use the canonical model name (strip provider prefix)
+            canonical_model = _strip_provider_prefix(
+                context.candidate_models[0] if context.candidate_models else "unknown"
+            )
+            raw = f"{canonical_model}:{text}"
+            return hashlib.sha256(raw.encode()).hexdigest()
+
+        return None
+
+    def _get_pinned_deployment(self, fingerprint: str) -> str | None:
+        """Return the pinned deployment model if the pin is valid and not expired."""
+        entry = self._pin_map.get(fingerprint)
+        if entry is None:
+            return None
+        model, expiry = entry
+        if time.monotonic() > expiry:
+            # Expired: remove from pin map and LRU tracking
+            self._pin_map.pop(fingerprint, None)
+            try:
+                self._pin_order.remove(fingerprint)
+            except ValueError:
+                pass
+            return None
+        # Move to end of LRU order (most recently used)
+        try:
+            self._pin_order.remove(fingerprint)
+        except ValueError:
+            pass
+        self._pin_order.append(fingerprint)
+        return model
+
+    def _set_pin(self, fingerprint: str, deployment_model: str) -> None:
+        """Create or update a pin for this fingerprint."""
+        expiry = time.monotonic() + _PIN_TTL_SECONDS
+        self._pin_map[fingerprint] = (deployment_model, expiry)
+
+        # Track LRU order
+        try:
+            self._pin_order.remove(fingerprint)
+        except ValueError:
+            pass
+        self._pin_order.append(fingerprint)
+
+        # Evict oldest entries if over cap
+        while len(self._pin_map) > _PIN_MAP_MAX:
+            oldest = self._pin_order.pop(0)
+            self._pin_map.pop(oldest, None)
+
     async def run(self, context: RoutingContext) -> RoutingContext:
         try:
             candidates = context.candidate_models
@@ -229,9 +318,28 @@ class LlamaSwapAffinityPlugin:
 
             # Both candidates are loaded and ready: route by actual
             # llama.cpp slot occupancy instead of LiteLLM's own counter.
+            # First check for session stickiness.
+            fingerprint = self._compute_fingerprint(context)
+            if fingerprint is not None:
+                pinned = self._get_pinned_deployment(fingerprint)
+                if pinned and pinned in ready_candidates:
+                    context.candidate_models = [pinned]
+                    context.signals["llama_swap_affinity"] = "sticky_to_pinned"
+                    return context
+                elif pinned:
+                    # Pinned GPU is not ready (starting/stopping) - fall
+                    # through to least-busy and create a new pin below.
+                    pass
+
             winner = await self._pick_least_busy(ready_candidates, candidate_ids)
             context.candidate_models = [winner]
             context.signals["llama_swap_affinity"] = "narrowed_to_least_busy_slot"
+
+            # Establish a new pin if we have a fingerprint and this GPU is
+            # ready (not starting).
+            if fingerprint is not None and running.get(candidate_ids[winner]) == "ready":
+                self._set_pin(fingerprint, winner)
+
             return context
         except Exception:
             # Fail open: routing must never break because llama-swap is


### PR DESCRIPTION
## Summary

Improve token caching in the LiteLLM/llama-swap stack by implementing session stickiness in the routing plugin and adding Grafana panels to measure KV cache efficiency.

### Problem

The 0.16% cache hit ratio in the LiteLLM admin UI refers to the Redis exact-match response cache (expected near-zero for chat). The real token caching happens at the llama.cpp layer via KV cache reuse, but it was being defeated because the `llama_swap_affinity` plugin alternated consecutive chat turns between GPU0 and GPU1 via round-robin tie-breaking.

### Changes

**`llama_swap_affinity.py`** (+108 lines)
- Added content-fingerprint pin map (sha256 of `model:first_user_message[:500]`)
- 1h TTL, 10k LRU cap
- In the `both ready` branch: check pin before least-busy; establish new pin after routing

**`llama-swap.json`** (4 new panels in "Efficiency" row)
- KV Cache Hit Ratio % (stat)
- KV Cache Hit Ratio Over Time (timeseries)
- KV Cache Reused Tokens (timeseries)
- Prompt Processing Ratio (timeseries)

Metrics use estimation: `1 - (llamacpp:prompt_tokens_total / litellm_input_tokens_metric_total)`

**`README.md`** (+40 lines)
- Documented sticky routing behavior
- Added KV cache efficiency subsection

### Validation

```
k8s-gitops-ci test --app kubernetes/llm --cluster okd --assume-openshift --disable-checks avp
```

All checks passed.