### PR TITLE
fix(vms/base/fedora.yaml): correct KubeVirt template spec indentation

### DIFF
--- a/vms/base/fedora.yaml
+++ b/vms/base/fedora.yaml
@@ -38,29 +38,29 @@ spec:
       labels:
         kubevirt.io/domain: fedora
         kubevirt.io/size: small
-      spec:
-        tolerations:
-          - key: node-role.kubernetes.io/gpu
-            operator: Exists
-            effect: NoSchedule
-        affinity:
-          nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
-                preference:
-                  matchExpressions:
-                    - key: node-role.kubernetes.io/gpu
-                      operator: In
-                      values:
-                        - "true"
-        # accessCredentials:
-        #   - sshPublicKey:
-        #       propagationMethod:
-        #         noCloud: {}
-        #       source:
-        #         secret:
-        #           secretName: ryzen-orange-rodent-83
-        architecture: amd64
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/gpu
+          operator: Exists
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/gpu
+                    operator: In
+                    values:
+                      - "true"
+      # accessCredentials:
+      #   - sshPublicKey:
+      #       propagationMethod:
+      #         noCloud: {}
+      #       source:
+      #         secret:
+      #           secretName: ryzen-orange-rodent-83
+      architecture: amd64
       domain:
         cpu:
           cores: 8


### PR DESCRIPTION
## Problem

KubeVirt admission webhook denied the VM with errors like:
```
spec.template.metadata.domain in body is a forbidden property
spec.template.metadata.networks in body is a forbidden property
spec.template.metadata.volumes in body is a forbidden property
spec.template.metadata.evictionStrategy in body is a forbidden property
spec.template.metadata.terminationGracePeriodSeconds in body is a forbidden property
spec.template.metadata.spec in body is a forbidden property
```

## Root Cause

The VirtualMachine spec had `spec:`, `domain:`, `networks:`, `volumes:`, `evictionStrategy:`, and `terminationGracePeriodSeconds:` nested as children of `spec.template.metadata` instead of being properly structured under `spec.template.spec`.

In KubeVirt's VirtualMachine CRD:
- `spec.template.metadata` only accepts labels and annotations
- `spec.template.spec` is where `domain`, `networks`, `volumes`, `evictionStrategy`, and `terminationGracePeriodSeconds` belong

## Fix

Corrected the indentation so `spec:` is a sibling of `metadata:` under `template:`, and all VM spec fields (domain, networks, volumes, evictionStrategy, terminationGracePeriodSeconds) are nested under `spec.template.spec`.