### PR TITLE
fix(llm): x-session-id propagation

### DIFF
--- a/kubernetes/llm/components/open-webui/deployment.yaml
+++ b/kubernetes/llm/components/open-webui/deployment.yaml
@@ -41,7 +41,9 @@ spec:
       containers:
         - name: open-webui
           # renovate: datasource=docker depName=ghcr.io/open-webui/open-webui
-          image: ghcr.io/open-webui/open-webui:v0.11.0@sha256:72c0ba641ba75e7aa52655cb242570906ececd09b1140fb736483038a22b3228
+          # image: ghcr.io/open-webui/open-webui:v0.11.0@sha256:72c0ba641ba75e7aa52655cb242570906ececd09b1140fb736483038a22b3228
+          # renovate: datasource=docker depName=registry.arthurvardevanyan.com/homelab/open-webui
+          image: registry.arthurvardevanyan.com/homelab/open-webui:v0.11.0-hotfix@sha256:8651ff2a2bb2d6574a8078acacbecea1da7bf2e5a45345d2f3bb5d5d6e2c7c41
           imagePullPolicy: IfNotPresent
           args:
             - bash


### PR DESCRIPTION
## OpenWebUI Session ID Forwarding Fix

This PR deploys the updated OpenWebUI image that forwards `X-Session-ID` headers from incoming API requests to the upstream LLM, fixing session tracking in llama-swap's Activity page for clients like OpenCode.

### Background

- **GitHub Discussion**: https://github.com/open-webui/open-webui/discussions/28931
- **Related Issue**: https://github.com/open-webui/open-webui/issues/28935

### Root Cause

OpenCode sends `X-Session-ID` in request headers, but OpenWebUI's `get_headers_and_cookies()` was ignoring it when making the internal call to the LLM backend (LiteLLM). This caused session IDs to be blank in llama-swap's Activity page.

### The Fix

Added header forwarding in `open_webui/routers/openai.py`:

```python
# Forward X-Session-ID from incoming request headers if present.
x_session_id = request.headers.get('x-session-id')
if x_session_id and 'X-Session-ID' not in headers:
    headers['X-Session-ID'] = x_session_id
```

### Upstream PR

- **OpenWebUI PR**: https://github.com/ArthurVardevanyan/open-webui/pull/3
  - Currently targets the fork — needs base changed to `open-webui:main` via GitHub UI before merging upstream
  - Includes the fix described above with full description and references

### Verification

Session ID (`ses_fd1409aaeffeEuTz6cyVFBmflb`) now appears in llama-swap's Activity page for both GUI and API requests.