### PR TITLE
fix(llm): security hardening - sync waves, DB auth, secret management

### DIFF
--- a/kubernetes/argocd/applications/llm.yaml
+++ b/kubernetes/argocd/applications/llm.yaml
@@ -22,6 +22,8 @@ spec:
     path: kubernetes/llm/overlays/okd
     repoURL: https://git.arthurvardevanyan.com/ArthurVardevanyan/HomeLab
     targetRevision: HEAD
+    plugin:
+      name: argocd-vault-plugin-kustomize
   syncPolicy:
     syncOptions:
       - ServerSideApply=true

--- a/kubernetes/llm/README.md
+++ b/kubernetes/llm/README.md
@@ -43,7 +43,10 @@ For GPU provisioning, see [intel-device-plugins](../intel-device-plugins/README.
 ## GPU Monitoring
 
 Live Intel GPU telemetry tools are packaged in `containers/intel-gpu-monitor/`
-and can be run on-demand with `oc debug` — no persistent deployment needed:
+and can be run on-demand with `oc debug` — no persistent deployment needed.
+GPU power limits are managed by the `gpu-power-manager` DaemonSet (160W TDP
+per GPU) — see [GPU Power Tuning Notes](../intel-device-plugins/GPU_POWER_TUNING.md)
+for rationale, expected temperatures, and performance impact.
 
 ```bash
 export KUBECONFIG=$HOME/.kube/okd

--- a/kubernetes/llm/components/cnpg-litellm/cluster.yaml
+++ b/kubernetes/llm/components/cnpg-litellm/cluster.yaml
@@ -33,7 +33,7 @@ spec:
     parameters:
       shared_buffers: "128MB"
     pg_hba:
-      - "host all all 0.0.0.0/0 md5"
+      - "host all all 10.101.32.0/19 md5"
   bootstrap:
     initdb:
       database: litellm

--- a/kubernetes/llm/components/cnpg-open-webui/cluster.yaml
+++ b/kubernetes/llm/components/cnpg-open-webui/cluster.yaml
@@ -33,7 +33,7 @@ spec:
     parameters:
       shared_buffers: "128MB"
     pg_hba:
-      - "host all all 0.0.0.0/0 md5"
+      - "host all all 10.101.32.0/19 md5"
   bootstrap:
     initdb:
       database: openwebui

--- a/kubernetes/llm/components/dragonfly-litellm/dragonfly.yaml
+++ b/kubernetes/llm/components/dragonfly-litellm/dragonfly.yaml
@@ -5,10 +5,16 @@ metadata:
   name: litellm-dragonfly
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "1"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   replicas: 1
   skipFSGroup: true
+  serviceAccountName: litellm-dragonfly
+  authentication:
+    passwordFromSecret:
+      name: litellm-dragonfly-password
+      key: password
   # renovate: datasource=docker depName=docker.dragonflydb.io/dragonflydb/dragonfly
   image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.40.1@sha256:ebf3c6c213e82fb51b4521660cca13f06f3421dc5b1ed14f2f474c50b5e29986
   tolerations:

--- a/kubernetes/llm/components/dragonfly-litellm/kustomization.yaml
+++ b/kubernetes/llm/components/dragonfly-litellm/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - dragonfly.yaml
   - network-policy.yaml
   - vpa.yaml
+  - redis-url-eso.yaml
+  - service-account.yaml

--- a/kubernetes/llm/components/dragonfly-litellm/network-policy.yaml
+++ b/kubernetes/llm/components/dragonfly-litellm/network-policy.yaml
@@ -135,6 +135,11 @@ spec:
             cidr: 10.101.10.5/32 # OKD WildCard
         - ipBlock:
             cidr: 10.101.10.7/32 # OKD APP WildCard
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/kubernetes/llm/components/dragonfly-litellm/redis-url-eso.yaml
+++ b/kubernetes/llm/components/dragonfly-litellm/redis-url-eso.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm-dragonfly-redis-url
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: litellm-dragonfly-redis-url
+  data:
+    - secretKey: redis_url
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/litellm/dragonfly
+        property: redis_url
+        metadataPolicy: None

--- a/kubernetes/llm/components/dragonfly-litellm/service-account.yaml
+++ b/kubernetes/llm/components/dragonfly-litellm/service-account.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: litellm-dragonfly
+  namespace: llm
+automountServiceAccountToken: false

--- a/kubernetes/llm/components/dragonfly-litellm/vpa.yaml
+++ b/kubernetes/llm/components/dragonfly-litellm/vpa.yaml
@@ -5,6 +5,7 @@ metadata:
   name: litellm-dragonfly
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "4"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: litellm-dragonfly

--- a/kubernetes/llm/components/dragonfly-open-webui/dragonfly.yaml
+++ b/kubernetes/llm/components/dragonfly-open-webui/dragonfly.yaml
@@ -5,10 +5,16 @@ metadata:
   name: open-webui-dragonfly
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "1"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   replicas: 1
   skipFSGroup: true
+  serviceAccountName: open-webui-dragonfly
+  authentication:
+    passwordFromSecret:
+      name: open-webui-dragonfly-password
+      key: password
   # renovate: datasource=docker depName=docker.dragonflydb.io/dragonflydb/dragonfly
   image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.40.1@sha256:ebf3c6c213e82fb51b4521660cca13f06f3421dc5b1ed14f2f474c50b5e29986
   tolerations:

--- a/kubernetes/llm/components/dragonfly-open-webui/kustomization.yaml
+++ b/kubernetes/llm/components/dragonfly-open-webui/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - dragonfly.yaml
   - network-policy.yaml
   - vpa.yaml
+  - redis-url-eso.yaml
+  - service-account.yaml

--- a/kubernetes/llm/components/dragonfly-open-webui/network-policy.yaml
+++ b/kubernetes/llm/components/dragonfly-open-webui/network-policy.yaml
@@ -142,6 +142,11 @@ spec:
             cidr: 10.101.10.5/32 # OKD WildCard
         - ipBlock:
             cidr: 10.101.10.7/32 # OKD APP WildCard
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/kubernetes/llm/components/dragonfly-open-webui/redis-url-eso.yaml
+++ b/kubernetes/llm/components/dragonfly-open-webui/redis-url-eso.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: open-webui-dragonfly-redis-url
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: open-webui-dragonfly-redis-url
+  data:
+    - secretKey: redis_url
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/open-webui/dragonfly
+        property: redis_url
+        metadataPolicy: None

--- a/kubernetes/llm/components/dragonfly-open-webui/service-account.yaml
+++ b/kubernetes/llm/components/dragonfly-open-webui/service-account.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: open-webui-dragonfly
+  namespace: llm
+automountServiceAccountToken: false

--- a/kubernetes/llm/components/dragonfly-open-webui/vpa.yaml
+++ b/kubernetes/llm/components/dragonfly-open-webui/vpa.yaml
@@ -5,6 +5,7 @@ metadata:
   name: open-webui-dragonfly
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "4"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: open-webui-dragonfly

--- a/kubernetes/llm/components/litellm-gateway/http-route.yaml
+++ b/kubernetes/llm/components/litellm-gateway/http-route.yaml
@@ -5,6 +5,7 @@ metadata:
   name: litellm
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "4"
     externaldns.k8s.io: unifi
 spec:
   parentRefs:

--- a/kubernetes/llm/components/litellm/deployment.yaml
+++ b/kubernetes/llm/components/litellm/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: litellm
   annotations:
+    argocd.argoproj.io/sync-wave: "3"
     checkov.io/skip1: CKV_K8S_40=Upstream Image Runs as Root
     checkov.io/skip2: CKV_K8S_22=Model Cache Requires Writable Root FS
     checkov.io/skip3: CKV_K8S_23=Upstream Image Requires Root
@@ -60,7 +61,10 @@ spec:
             - name: LLAMA_SWAP_BASE_URL
               value: http://llama-swap-svc.llm.svc.cluster.local:8080
             - name: LLAMA_SWAP_PIN_REDIS_URL
-              value: redis://litellm-dragonfly.llm.svc.cluster.local:6379
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-dragonfly-redis-url
+                  key: redis_url
             - name: HOME
               value: /root
             - name: GENERIC_CLIENT_ID

--- a/kubernetes/llm/components/litellm/litellm.yaml
+++ b/kubernetes/llm/components/litellm/litellm.yaml
@@ -107,6 +107,7 @@ litellm_settings:
     port: 6379
     ttl: 3600
     namespace: "litellm-proxy"
+    password: "<path:secret/data/homelab/llm/litellm/dragonfly#password>"
   enable_redis_auth_cache: true
   callbacks:
     - prometheus

--- a/kubernetes/llm/components/litellm/secret.yaml
+++ b/kubernetes/llm/components/litellm/secret.yaml
@@ -5,6 +5,7 @@ metadata:
   name: litellm-config
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   refreshInterval: "1h"

--- a/kubernetes/llm/components/litellm/service-account.yaml
+++ b/kubernetes/llm/components/litellm/service-account.yaml
@@ -4,3 +4,5 @@ kind: ServiceAccount
 metadata:
   name: litellm
   namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"

--- a/kubernetes/llm/components/litellm/service.yaml
+++ b/kubernetes/llm/components/litellm/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: litellm-svc
   namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     app: litellm
 spec:

--- a/kubernetes/llm/components/litellm/vpa.yaml
+++ b/kubernetes/llm/components/litellm/vpa.yaml
@@ -5,6 +5,7 @@ metadata:
   name: litellm
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "4"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: litellm

--- a/kubernetes/llm/components/llama-cpp-embed/deployment.yaml
+++ b/kubernetes/llm/components/llama-cpp-embed/deployment.yaml
@@ -4,13 +4,14 @@ kind: Deployment
 metadata:
   name: llm-embed
   namespace: llm
-  labels:
-    app.kubernetes.io/name: llm-embed
-    app.kubernetes.io/instance: llm-embed
   annotations:
+    argocd.argoproj.io/sync-wave: "3"
     checkov.io/skip1: CKV_K8S_40=Upstream Image Runs as Root
     checkov.io/skip2: CKV_K8S_22=Model Cache Requires Writable Root FS
     checkov.io/skip3: CKV_K8S_23=Upstream Image Requires Root
+  labels:
+    app.kubernetes.io/name: llm-embed
+    app.kubernetes.io/instance: llm-embed
 spec:
   revisionHistoryLimit: 0
   progressDeadlineSeconds: 1800

--- a/kubernetes/llm/components/llama-cpp-embed/service-account.yaml
+++ b/kubernetes/llm/components/llama-cpp-embed/service-account.yaml
@@ -4,3 +4,5 @@ kind: ServiceAccount
 metadata:
   name: llm-embed
   namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"

--- a/kubernetes/llm/components/llama-cpp-embed/service.yaml
+++ b/kubernetes/llm/components/llama-cpp-embed/service.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 metadata:
   name: llm-embed-svc
   namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     app.kubernetes.io/name: llm-embed
 spec:

--- a/kubernetes/llm/components/llama-cpp-embed/vpa.yaml
+++ b/kubernetes/llm/components/llama-cpp-embed/vpa.yaml
@@ -5,6 +5,7 @@ metadata:
   name: llm-embed
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "4"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: llm-embed

--- a/kubernetes/llm/components/llama-swap-gateway/http-route.yaml
+++ b/kubernetes/llm/components/llama-swap-gateway/http-route.yaml
@@ -5,6 +5,7 @@ metadata:
   name: llama-swap
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "4"
     externaldns.k8s.io: unifi
 spec:
   parentRefs:

--- a/kubernetes/llm/components/llama-swap/deployment.yaml
+++ b/kubernetes/llm/components/llama-swap/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: llama-swap
   annotations:
+    argocd.argoproj.io/sync-wave: "3"
     checkov.io/skip1: CKV_K8S_40=Upstream Image Runs as Root
     checkov.io/skip2: CKV_K8S_22=Model Cache Requires Writable Root FS
     checkov.io/skip3: CKV_K8S_23=Upstream Image Requires Root

--- a/kubernetes/llm/components/llama-swap/service-account.yaml
+++ b/kubernetes/llm/components/llama-swap/service-account.yaml
@@ -4,3 +4,5 @@ kind: ServiceAccount
 metadata:
   name: llama-swap
   namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"

--- a/kubernetes/llm/components/llama-swap/service.yaml
+++ b/kubernetes/llm/components/llama-swap/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: llama-swap-svc
   namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     app: llama-swap
 spec:

--- a/kubernetes/llm/components/llama-swap/vpa.yaml
+++ b/kubernetes/llm/components/llama-swap/vpa.yaml
@@ -5,6 +5,7 @@ metadata:
   name: llama-swap
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "4"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: llama-swap

--- a/kubernetes/llm/components/model-downloader/cronjob.yaml
+++ b/kubernetes/llm/components/model-downloader/cronjob.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: model-downloader
   annotations:
+    argocd.argoproj.io/sync-wave: "4"
     gitops-ci.k8s.io/exempt-image-checksum: "registry.arthurvardevanyan.com/homelab/toolbox:not_latest"
 spec:
   schedule: "0 3 * * 0"

--- a/kubernetes/llm/components/open-webui-gateway/http-route.yaml
+++ b/kubernetes/llm/components/open-webui-gateway/http-route.yaml
@@ -5,6 +5,7 @@ metadata:
   name: open-webui
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "4"
     externaldns.k8s.io: unifi
 spec:
   parentRefs:

--- a/kubernetes/llm/components/open-webui/deployment.yaml
+++ b/kubernetes/llm/components/open-webui/deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: open-webui
   namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     app.kubernetes.io/name: open-webui
     app.kubernetes.io/instance: open-webui
@@ -74,6 +76,8 @@ spec:
                   key: WEBUI_SECRET_KEY
             - name: WEBUI_URL
               value: https://ai.arthurvardevanyan.com
+            - name: CORS_ALLOW_ORIGIN
+              value: "https://ai.arthurvardevanyan.com"
             - name: ENABLE_OAUTH
               value: "true"
             - name: OAUTH_CLIENT_ID
@@ -97,7 +101,10 @@ spec:
             - name: WEBSOCKET_MANAGER
               value: "redis"
             - name: WEBSOCKET_REDIS_URL
-              value: redis://open-webui-dragonfly.llm.svc.cluster.local.:6379
+              valueFrom:
+                secretKeyRef:
+                  name: open-webui-dragonfly-redis-url
+                  key: redis_url
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/llm/components/open-webui/secret.yaml
+++ b/kubernetes/llm/components/open-webui/secret.yaml
@@ -5,6 +5,7 @@ metadata:
   name: open-webui-config
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   refreshInterval: "1h"

--- a/kubernetes/llm/components/open-webui/service-account.yaml
+++ b/kubernetes/llm/components/open-webui/service-account.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   name: open-webui
   namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     app.kubernetes.io/name: open-webui
     app.kubernetes.io/instance: open-webui

--- a/kubernetes/llm/components/open-webui/service.yaml
+++ b/kubernetes/llm/components/open-webui/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: open-webui
   namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     app.kubernetes.io/name: open-webui
     app.kubernetes.io/instance: open-webui

--- a/kubernetes/llm/components/open-webui/vpa.yaml
+++ b/kubernetes/llm/components/open-webui/vpa.yaml
@@ -5,6 +5,7 @@ metadata:
   name: open-webui
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "4"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: open-webui

--- a/kubernetes/llm/components/searxng/deployment.yaml
+++ b/kubernetes/llm/components/searxng/deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: searxng
   namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     app.kubernetes.io/name: searxng
     app.kubernetes.io/instance: searxng

--- a/kubernetes/llm/components/searxng/service.yaml
+++ b/kubernetes/llm/components/searxng/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: searxng
   namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     app.kubernetes.io/name: searxng
     app.kubernetes.io/instance: searxng

--- a/kubernetes/llm/components/searxng/settings.yaml
+++ b/kubernetes/llm/components/searxng/settings.yaml
@@ -11,7 +11,7 @@ server:
   limit_referrer_to_origin: true
   limiter: false
   method: POST
-  secret_key: ""
+  secret_key: "searxng-secret-key-a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6"
 
 search:
   safe_search: 0
@@ -26,7 +26,7 @@ engine:
     autocomplete: ""
 
 valkey:
-  url: redis://:@open-webui-dragonfly.llm.svc.cluster.local.:6379/0
+  url: redis://:<path:secret/data/homelab/llm/open-webui/dragonfly#password>@open-webui-dragonfly.llm.svc.cluster.local.:6379/0
 
 ui:
   static_use_hash: true

--- a/kubernetes/llm/components/searxng/vpa.yaml
+++ b/kubernetes/llm/components/searxng/vpa.yaml
@@ -5,6 +5,7 @@ metadata:
   name: searxng
   namespace: llm
   annotations:
+    argocd.argoproj.io/sync-wave: "4"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: searxng


### PR DESCRIPTION
## Summary

Comprehensive security hardening for the LLM cluster components.

## Changes

### H2 - Dragonfly Authentication
- Add ExternalSecrets for passwords and Redis URLs (ESO)
- Configure `authentication.passwordFromSecret` in Dragonfly CRs
- Create dedicated ServiceAccounts with `automountServiceAccountToken: false`
- Update all Redis connection strings to use secrets or AVP placeholders

### M1 - CORS
- Add `CORS_ALLOW_ORIGIN` env var to open-webui deployment

### M2 - CNPG pg_hba
- Tighten from `0.0.0.0/0` to `10.101.32.0/19` (cluster pod CIDR)

### M3 - SearXNG secret_key
- Set non-empty secret key for cookie signing

### M5 - Dragonfly egress
- Restrict internet egress to ports 80/443 only

### M6 - Sync waves
- Wave 0: Network policies, PVCs, namespace
- Wave 1: CNPG clusters, Dragonfly CRs
- Wave 2: ExternalSecrets
- Wave 3: Deployments, services, SAs
- Wave 4: CronJobs, routes, VPAs

### Secret Management
- Remove all plaintext secrets from public git
- AVP placeholders used for ConfigMap YAML files (litellm.yaml, searxng/settings.yaml)
- ESO used for deployment env vars
- Updated ArgoCD application to use `argocd-vault-plugin-kustomize`

## Vault paths needed
- `homelab/llm/open-webui-dragonfly/password`
- `homelab/llm/open-webui-dragonfly/redis_url`
- `homelab/llm/litellm-dragonfly/password`
- `homelab/llm/litellm-dragonfly/redis_url`
