### PR TITLE
chore(dns): add to tainted nodes

### DIFF
--- a/okd/okd-configuration/base/kustomization.yaml
+++ b/okd/okd-configuration/base/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - operators/image-registry.yaml
   - operators/samples.yaml
   - operators/console.yaml
+  - operators/dns.yaml
   - admin-acks.yaml
   - ./installplan-rbac.yaml
   - core-password.yaml

--- a/okd/okd-configuration/base/operators/dns.yaml
+++ b/okd/okd-configuration/base/operators/dns.yaml
@@ -1,0 +1,25 @@
+apiVersion: operator.openshift.io/v1
+kind: DNS
+metadata:
+  name: default
+spec:
+  cache:
+    negativeTTL: 0s
+    positiveTTL: 0s
+  logLevel: Normal
+  nodePlacement:
+    tolerations:
+      - key: node-role.kubernetes.io/infra
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/gpu
+        operator: Exists
+        effect: NoSchedule
+  operatorLogLevel: Normal
+  upstreamResolvers:
+    policy: Sequential
+    protocolStrategy: ""
+    transportConfig: {}
+    upstreams:
+      - port: 53
+        type: SystemResolvConf


### PR DESCRIPTION
This pull request adds configuration for the DNS operator to the OKD cluster setup. The main change is the introduction of a new `dns.yaml` file that defines the DNS operator's settings, along with updating the base kustomization to include this new resource.

DNS operator integration:

* Added `operators/dns.yaml` to the `resources` list in `okd-configuration/base/kustomization.yaml`, ensuring the DNS operator is managed as part of the cluster configuration.
* Introduced a new `okd-configuration/base/operators/dns.yaml` file that defines the DNS operator resource with custom settings for cache TTLs, log levels, node placement tolerations, and upstream resolver configuration.