### PR TITLE
chore(postgres): increase wal_keep_size for all CNPG clusters

### DIFF
--- a/kubernetes/gitea/components/cnpg/cluster.yaml
+++ b/kubernetes/gitea/components/cnpg/cluster.yaml
@@ -31,6 +31,7 @@ spec:
       shared_buffers: "128MB"
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
+      wal_keep_size: "1GB"
     pg_hba:
       - "host all all 0.0.0.0/0 trust"
   bootstrap:

--- a/kubernetes/grafana/components/cnpg/cluster.yaml
+++ b/kubernetes/grafana/components/cnpg/cluster.yaml
@@ -31,6 +31,7 @@ spec:
       shared_buffers: "128MB"
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
+      wal_keep_size: "1GB"
     pg_hba:
       - "host all all 0.0.0.0/0 trust"
   bootstrap:

--- a/kubernetes/homeassistant/components/cnpg/cluster.yaml
+++ b/kubernetes/homeassistant/components/cnpg/cluster.yaml
@@ -31,6 +31,9 @@ spec:
       shared_buffers: "256MB"
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
+      min_wal_size: "1GB"
+      max_wal_size: "4GB"
+      wal_keep_size: "4GB"
     pg_hba:
       - "host all all 0.0.0.0/0 trust"
   bootstrap:

--- a/kubernetes/immich/components/cnpg/cluster.yaml
+++ b/kubernetes/immich/components/cnpg/cluster.yaml
@@ -31,6 +31,9 @@ spec:
       shared_buffers: "128MB"
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
+      min_wal_size: "512MB"
+      max_wal_size: "2GB"
+      wal_keep_size: "2GB"
     pg_hba:
       - "host all all 0.0.0.0/0 trust"
   bootstrap:

--- a/kubernetes/llm/components/cnpg-litellm/cluster.yaml
+++ b/kubernetes/llm/components/cnpg-litellm/cluster.yaml
@@ -32,6 +32,7 @@ spec:
   postgresql:
     parameters:
       shared_buffers: "128MB"
+      wal_keep_size: "2GB"
     pg_hba:
       - "host all all 10.101.32.0/19 md5"
   bootstrap:

--- a/kubernetes/llm/components/cnpg-open-webui/cluster.yaml
+++ b/kubernetes/llm/components/cnpg-open-webui/cluster.yaml
@@ -32,6 +32,7 @@ spec:
   postgresql:
     parameters:
       shared_buffers: "128MB"
+      wal_keep_size: "2GB"
     pg_hba:
       - "host all all 10.101.32.0/19 md5"
   bootstrap:

--- a/kubernetes/nextcloud-fpm/components/cnpg/cluster.yaml
+++ b/kubernetes/nextcloud-fpm/components/cnpg/cluster.yaml
@@ -32,6 +32,9 @@ spec:
       max_connections: "300"
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
+      min_wal_size: "1GB"
+      max_wal_size: "4GB"
+      wal_keep_size: "4GB"
     pg_hba:
       - "host all all 0.0.0.0/0 trust"
   bootstrap:

--- a/kubernetes/quay/components/cnpg-quay/cluster.yaml
+++ b/kubernetes/quay/components/cnpg-quay/cluster.yaml
@@ -31,6 +31,7 @@ spec:
       shared_buffers: "256MB"
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
+      wal_keep_size: "2GB"
     pg_hba:
       - "host all all 0.0.0.0/0 trust"
   bootstrap:

--- a/kubernetes/stackrox-central/components/cnpg/cluster.yaml
+++ b/kubernetes/stackrox-central/components/cnpg/cluster.yaml
@@ -31,6 +31,7 @@ spec:
       shared_buffers: "256MB"
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
+      wal_keep_size: "2GB"
     pg_hba:
       - "host all all 0.0.0.0/0 trust"
   bootstrap:

--- a/kubernetes/zitadel/components/cnpg/cluster.yaml
+++ b/kubernetes/zitadel/components/cnpg/cluster.yaml
@@ -31,6 +31,7 @@ spec:
       shared_buffers: "128MB"
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
+      wal_keep_size: "1GB"
     pg_hba:
       - "host all all 0.0.0.0/0 trust"
   bootstrap:


### PR DESCRIPTION
## Summary

Increased `wal_keep_size` across all CNPG clusters to prevent replica recovery failures during failovers.

## Changes by tier

| Tier | Clusters | Old | New |
|------|----------|-----|-----|
| Light | gitea, grafana, zitadel | 512MB | 1GB |
| Medium | litellm, open-webui, quay, stackrox, immich | 512MB | 2GB |
| Heavy | homeassistant, nextcloud | 512MB | 4GB |

## Additional tuning

Added `min_wal_size` and `max_wal_size` for heavy workloads:

- homeassistant: min=1GB, max=4GB
- immich: min=512MB, max=2GB
- nextcloud: min=1GB, max=4GB

These encourage more frequent WAL file rotation, making `wal_keep_size` cover more distinct WAL segments.

## Context

All clusters had `wal_keep_size: 512MB` — insufficient for failover scenarios where WAL gets recycled before replicas can reconnect. The nextcloud cluster experienced a cascading failover that left both replicas unable to recover due to WAL divergence.