### PR TITLE
feat(gpu): enable N+1 guaranteed GPU spread for llama-swap + transcode coexistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ graph TD
 | **PCI Slot 1**   | Gen4 x4, `0000:06:00.0` (top slot, direct CPU lanes)                                                                               |
 | **PCI Slot 2**   | Gen3 x4, `0000:2d:00.0` (bottom slot, B550 chipset lanes)                                                                          |
 | **KMD**          | `xe`                                                                                                                               |
-| **K8s Resource** | `gpu.intel.com/xe` — 2 allocatable (one per physical card, no fan-out)                                                             |
+| **K8s Resource** | `gpu.intel.com/xe` — 6 allocatable (3 per card, balanced; LLM reserves 4 to span both)                                             |
 | **Workload**     | Transcoding (Plex/Immich, VA-API), LLM inference (llama.cpp Vulkan), AI/ML experiments                                             |
 | **Power Tuning** | ~155W per GPU via privileged DaemonSet — see [gpu-power-manager.yaml](kubernetes/intel-device-plugins/base/gpu-power-manager.yaml) |
 

--- a/kubernetes/intel-device-plugins/README.md
+++ b/kubernetes/intel-device-plugins/README.md
@@ -4,22 +4,36 @@ Installs the Intel Device Plugins Operator (via OLM) and a `GpuDevicePlugin`
 custom resource that advertises the Intel Arc Pro B70 (Battlemage / Xe2, `xe`
 KMD) to the kubelet as the `gpu.intel.com/xe` extended resource.
 
-> **[WARNING] Intel MIG (fan-out sharing) is currently DISABLED.** The
-> `GpuDevicePlugin` CR (`sharedDevNum: 1`) exposes each physical Intel Arc Pro
-> B70 GPU as exactly 1 allocatable device (`gpu.intel.com/xe: 2` total on
-> `gpu-1`). No GPU partitioning or MIG-style slicing is active. This is
-> intentional for the current LLM workload, which requires full GPUs
-> (`gpu.intel.com/xe: "2"` per pod). If you need to run partitioned GPU
-> workloads (e.g. transcoding servers, multi-tenant inference), you must:
+> **[GPU sharing is ENABLED] (`sharedDevNum: 3`, `balanced`).** The
+> `GpuDevicePlugin` CR exposes 3 virtual devices per physical Intel Arc Pro B70
+> GPU (`gpu.intel.com/xe: 6` total on `gpu-1`). The `balanced` allocation
+> policy spreads device registration across physical GPUs so kubelet first-fit
+> distributes them evenly: llama-swap requests `"4" > 3` (max one card can
+> supply) — this N+1 invariant forces the scheduler to draw from both cards
+> regardless of allocation policy, so `ONEAPI_DEVICE_SELECTOR=level_zero:0/1`
+> is always satisfied. The remaining 2 virtual devices (one per card) are left
+> for transcode pods that share a physical GPU with a resident LLM model.
 >
-> 1. **Bump `sharedDevNum`** in
+> **Transcode coexistence:** pods request `gpu.intel.com/xe: "1"` (one
+> concurrent transcode stream per physical GPU, max 2). Measured free headroom
+> with both LLM models loaded: ~2.4 GiB (35B card, `06:00.0`) / ~0.9 GiB
+> (27B card, `2d:00.0`). The xe KMD has `hw_memory_demand_paging=true` (pages
+> to host RAM), so slight overages degrade rather than hard-fail; keep
+> transcode streams modest (1080p-class). Also, VA-API/QSV applications cannot
+> auto-detect the correct render device on a multi-GPU host — transcode workloads
+> need explicit device specification (e.g. ffmpeg `-vaapi_device
+/dev/dri/renderDXXX`; see the Intel GPU plugin repo's `render-device.sh`
+> helper for locating the right device).
+>
+> **To change the sharing configuration:**
+>
+> 1. Edit `sharedDevNum` and/or `preferredAllocationPolicy` in
 >    `kubernetes/intel-device-plugins/base/gpu-device-plugin.yaml` (e.g.
->    `sharedDevNum: 3` gives 3 virtual indices per card).
-> 2. **Update workload resource requests** to consume fractional indices
->    (`gpu.intel.com/xe: "1"` for one slice, `"2"` for two slices, etc.).
+>    `sharedDevNum: 4` gives 4 virtual indices per card, 8 total).
+> 2. Keep llama-swap's request at `sharedDevNum + 1` for guaranteed spread.
 > 3. **Redeploy the device plugin** — the DaemonSet must roll to pick up the
 >    new CR spec (each card's `gpu.intel.com/xe` allocatable count will
->    change from `2` to `sharedDevNum × 2`).
+>    change to `sharedDevNum × 2`).
 > 4. **Verify** with `oc get node gpu-1 -o jsonpath='{.status.allocatable.gpu\.intel\.com/xe}'`
 >    before scheduling new workloads.
 

--- a/kubernetes/intel-device-plugins/base/gpu-device-plugin.yaml
+++ b/kubernetes/intel-device-plugins/base/gpu-device-plugin.yaml
@@ -2,11 +2,14 @@
 # GpuDevicePlugin custom resource consumed by the Intel Device Plugins Operator.
 # Advertises each Intel Arc Pro B70 (xe KMD) as the `gpu.intel.com/xe` resource.
 #
-# sharedDevNum: 1 -> one real device per physical GPU (no fan-out sharing).
-# Each card is a single allocatable device: gpu-1 reports
-# `gpu.intel.com/xe: 2`. If fan-out is ever needed, bump this number (e.g.
-# `sharedDevNum: 3` gives 3 virtual indices per card, indices 0-2 = GPU 0,
-# 3-5 = GPU 1).
+# sharedDevNum: 3 -> 3 virtual (shared) devices per physical GPU, gpu-1 reports
+# `gpu.intel.com/xe: 6`. preferredAllocationPolicy: balanced spreads devices
+# across physical GPUs. llama-swap requests "4" > 3 (max per card), so the
+# scheduler must draw from both cards regardless of policy -> ONEAPI
+# DEVICE_SELECTOR level_zero:0/1 always satisfiable. The remaining 2 virtual
+# devices are left for transcode pods sharing a physical GPU with an LLM
+# model. Bump sharedDevNum further (e.g. 4 -> 8 total) for more concurrent
+# transcode streams; llama-swap request stays "N+1" for guaranteed spread.
 #
 # With the OLM-installed operator, the operator supplies the plugin/init images
 # for the DaemonSet it manages, so we do NOT pin them here.
@@ -17,10 +20,10 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  sharedDevNum: 1
+  sharedDevNum: 3
   enableMonitoring: true
   monitoringMode: single
-  preferredAllocationPolicy: none
+  preferredAllocationPolicy: balanced
   logLevel: 2
   # Run the plugin DaemonSet ONLY on the GPU node (gpu-1), not on every worker.
   # Keyed off the same NFD custom label the llm-server Intel workload uses, produced

--- a/kubernetes/llm/components/llama-swap/deployment.yaml
+++ b/kubernetes/llm/components/llama-swap/deployment.yaml
@@ -95,12 +95,12 @@ spec:
               cpu: "2"
               memory: 12Gi
               ephemeral-storage: "256Mi"
-              gpu.intel.com/xe: "2"
+              gpu.intel.com/xe: "4"
             limits:
               cpu: "4"
               memory: 48Gi
               ephemeral-storage: "1Gi"
-              gpu.intel.com/xe: "2"
+              gpu.intel.com/xe: "4"
           volumeMounts:
             - name: config
               mountPath: /etc/llama-swap


### PR DESCRIPTION
## Summary

Bump `sharedDevNum` from 1 to 3 in the `GpuDevicePlugin` CR and raise llama-swap's GPU resource request to `sharedDevNum + 1 = 4`, enforcing a hard **N+1 capacity invariant** that guarantees llama-swap always spans both physical GPUs.

## Why N+1

With `sharedDevNum: 3`, each card reports 3 virtual devices (`gpu.intel.com/xe: 6` total). If llama-swap requests **4** (more than one card can supply: 3), the scheduler **must** draw from both cards regardless of allocation policy — `ONEAPI_DEVICE_SELECTOR=level_zero:0/1` is always satisfiable, even during llama-swap restarts while transcode pods hold device slices.

This is a **policy-independent guarantee**: works with `balanced`, `packed`, or first-fit. No fragile topology assumptions.

## Capacity

| Role | Virtual GPUs | Per card |
|---|---|---|
| llama-swap | 4 (reserved) | 2 from each card (under `balanced`) |
| transcode (future) | 2 (available) | 1 per card |

## Transcode coexistence notes

- **Max 2 concurrent transcode streams** (`gpu.intel.com/xe: "1"` each)
- Measured free headroom with both LLM models loaded: ~2.4 GiB (35B card) / ~0.9 GiB (27B card)
- xe KMD `hw_memory_demand_paging=true` — slight overages degrade rather than hard-fail
- VA-API/QSV workloads need explicit device spec (e.g. ffmpeg `-vaapi_device /dev/dri/renderDXXX`) — see intel-device-plugins README for details

## Changes

- `kubernetes/intel-device-plugins/base/gpu-device-plugin.yaml`: `sharedDevNum: 1→3`, header comment rewritten
- `kubernetes/llm/components/llama-swap/deployment.yaml`: `gpu.intel.com/xe: "2"→"4"` (requests + limits)
- `kubernetes/intel-device-plugins/README.md`: WARNING block → active-mode description
- `README.md` (root): K8s Resource row updated to 6 allocatable