### PR TITLE
fix(postgres): pin pgAdmin to 9.15 to work around login regression (FS-Too 5.8.2)

### DIFF
--- a/kubernetes/postgres/components/pg_admin/pg_admin.yaml
+++ b/kubernetes/postgres/components/pg_admin/pg_admin.yaml
@@ -7,6 +7,21 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
+  # Pinned to 9.15 to work around a login-breaking regression in the PGO 5.8.9
+  # default image (crunchy-pgadmin4:ubi9-9.17-2633).
+  #
+  # pgAdmin 9.17 ships Flask-Security-Too 5.8.2, which inverted the contract of
+  # User.is_locked(): 5.8.1 used `if not user.is_locked(...): return False`
+  # while 5.8.2 uses `if user.is_locked(...): return False`. pgAdmin's
+  # User.is_locked() (pgadmin/model/__init__.py) still returns True for an
+  # *unlocked* user, so LoginForm.validate() fails for every valid credential
+  # and POST /authenticate/login 302-redirects back to /login with no error.
+  # See https://github.com/pgadmin-org/pgadmin4/issues/10311
+  #
+  # 9.15 ships Flask-Security-Too 5.8.1 and shares the same alembic head
+  # (normalize_locked_text_default), so this is not a schema downgrade.
+  # Remove this pin once Crunchy publishes an image with the fix.
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi9-9.15-2621@sha256:2aca68f74a212fbeefb6ea4bddab3abab1604c0c367a9ddd8965397aec2a1558
   dataVolumeClaimSpec:
     storageClassName: rook-ceph-block-ci
     accessModes:

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,13 @@
   ],
   "packageRules": [
     {
+      "description": "pgAdmin 9.16+ reintroduces pgadmin-org/pgadmin4#10311 (Flask-Security-Too 5.8.2 inverted User.is_locked(), breaking all logins). Keep pinned to 9.15 until Crunchy ships a fixed image.",
+      "matchPackageNames": [
+        "registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4"
+      ],
+      "enabled": false
+    },
+    {
       "matchFileNames": ["containers/**"],
       "groupName": "Homelab Container Images",
       "separateMajorMinor": false


### PR DESCRIPTION
## Problem

pgAdmin 9.17 is **unusable** for login — every valid credential results in a 302 redirect back to `/login` with no error message and no login attempt counter increment.

## Root cause

pgAdmin 9.17 ships **Flask-Security-Too 5.8.2**, which **inverted the contract** of `User.is_locked()` compared to 5.8.1:

| Version | LoginForm.validate() check |
|---------|---------------------------|
| 5.8.1   | `if not self.user.is_locked(...): return False` |
| 5.8.2   | `if self.user.is_locked(...): return False` |

pgAdmin's `User.is_locked()` (pgadmin/model/__init__.py) was written for the 5.8.1 contract: it returns `True` for **unlocked** users. Under 5.8.2 this means every unlocked user gets `is_locked() == True`, so `LoginForm.validate()` rejects them all.

## Fix

Pin the PGAdmin image to **9.15** (`ubi9-9.15-2621`), which ships Flask-Security-Too 5.8.1 and uses the same alembic schema revision (`normalize_locked_text_default`) — zero risk of schema downgrade.

Also disable Renovate updates to prevent silent reversion to 9.16+.

## References

- [pgadmin-org/pgadmin4#10311](https://github.com/pgadmin-org/pgadmin4/issues/10311) — Login is impossible in pgAdmin 4 9.17 with Flask-Security-Too 5.8.2 because User.is_locked() has inverted semantics

## Changes

- `kubernetes/postgres/components/pg_admin/pg_admin.yaml` — add `spec.image` with digest-pinned tag
- `renovate.json` — disable updates to `crunchy-pgadmin4` until Crunchy ships a fixed image