### PR TITLE
feat(llm): add oikb daemon for multi-source knowledge sync

### DIFF
--- a/kubernetes/argocd/applications/kustomization.yaml
+++ b/kubernetes/argocd/applications/kustomization.yaml
@@ -69,6 +69,7 @@ resources:
   - okd-nodes.yaml
   - okd-virt.yaml
   - openshift-logging.yaml
+  - opentelemetry-operator.yaml
   - openshift-monitoring.yaml
   - openshift-nfd.yaml
   - postgres.yaml

--- a/kubernetes/argocd/applications/opentelemetry-operator.yaml
+++ b/kubernetes/argocd/applications/opentelemetry-operator.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opentelemetry-operator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    notifications.argoproj.io/subscribe.on-sync-succeeded.gh-cluster: ""
+    notifications.argoproj.io/subscribe.on-sync-failed.gh-cluster: ""
+    notifications.argoproj.io/subscribe.on-sync-status-unknown.gh-cluster: ""
+    notifications.argoproj.io/subscribe.on-health-degraded.gh-cluster: ""
+  labels:
+    app.kubernetes.io/instance: argocd
+spec:
+  destination:
+    namespace: opentelemetry-operator
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: kubernetes/opentelemetry-operator/overlays/okd
+    repoURL: https://git.arthurvardevanyan.com/ArthurVardevanyan/HomeLab
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - ServerSideApply=true
+      - CreateNamespace=true

--- a/kubernetes/grafana/base/dashboards/open-webui.json
+++ b/kubernetes/grafana/base/dashboards/open-webui.json
@@ -1,0 +1,382 @@
+{
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.4.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Open WebUI usage & request metrics exported via the OTEL collector bridge (openwebui_ prefix).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "HTTP request rate served by Open WebUI.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_route) (rate(openwebui_http_server_duration_milliseconds_count[5m]))",
+          "legendFormat": "{{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "p95 request latency.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, http_route) (rate(openwebui_http_server_duration_milliseconds_bucket[5m])))",
+          "legendFormat": "{{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request Latency (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total requests served (all routes).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "value": null
+            }
+          ],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(openwebui_http_server_duration_milliseconds_count[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Request Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5xx error rate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "value": null
+            },
+            {
+              "color": "red",
+              "value": 0.1
+            }
+          ],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(openwebui_http_server_duration_milliseconds_count{http_status_code=~\"5..\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "5xx Error Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Collector uptime — non-zero confirms the OTLP bridge is receiving data.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "value": null
+            },
+            {
+              "color": "green",
+              "value": 1
+            }
+          ],
+          "unit": "bool"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(openwebui_http_server_duration_milliseconds_count) > bool 0",
+          "refId": "A"
+        }
+      ],
+      "title": "Bridge Up",
+      "type": "stat"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["open-webui", "llm"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Prometheus",
+          "value": "Prometheus",
+          "selected": true
+        },
+        "hide": 0,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Open WebUI",
+  "uid": "open-webui",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/grafana/base/kustomization.yaml
+++ b/kubernetes/grafana/base/kustomization.yaml
@@ -28,6 +28,7 @@ configMapGenerator:
       - dashboards/loki.json
       - dashboards/node-exporter.json
       - dashboards/ntp.json
+      - dashboards/open-webui.json
       - dashboards/pfsense_lite.json
       - dashboards/version-checker.json
     name: grafana-dashboards

--- a/kubernetes/llm/components/knowledge-sync/config-map.yaml
+++ b/kubernetes/llm/components/knowledge-sync/config-map.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: knowledge-sync-config
+  namespace: llm
+  labels:
+    app.kubernetes.io/name: knowledge-sync
+    app.kubernetes.io/instance: knowledge-sync
+data:
+  # oikb daemon config (mounted at /app/.oikb.yaml). Each source syncs to its
+  # own Knowledge Base (one KB per source for clean retrieval and independent
+  # sync status/metrics). KB IDs and connector tokens are injected at runtime
+  # from the ESO Secret via ${VAR} interpolation — never committed here.
+  #
+  # Create each Knowledge Base in the Open WebUI UI first and record its ID in
+  # Vault under secret/data/homelab/llm/knowledge-sync (KB_*_ID).
+  #
+  # TODO: Jira/Discord/Slack connector env-var names are not listed in the
+  # public oikb guide. Confirm exact names per connector by running
+  #   oikb validate --deep   # (against this image, with creds set)
+  # and update the sources below before those syncs become active.
+  oikb.yaml: |-
+    defaults:
+      interval: 1h
+      concurrency: 4
+      filter:
+        max-size: 50mb
+
+    sources:
+      # Web / sitemap crawler (migrated from the previous bash CronJob).
+      - name: personal-site
+        source: sitemap:https://www.arthurvardevanyan.com/sitemap.xml
+        kb-id: ${KB_PERSONAL_SITE_ID}
+
+      # GitHub (private repo; read-only fine-grained PAT reuses mcp-github).
+      - name: homelab
+        source: github:${GITHUB_ORG}/HomeLab
+        kb-id: ${KB_HOMELAB_ID}
+        token: ${GITHUB_TOKEN}
+
+      # Nextcloud (WebDAV app password).
+      - name: documents
+        source: "nextcloud:/Documents"
+        kb-id: ${KB_DOCUMENTS_ID}
+
+      # Jira.
+      # TODO: confirm exact env-var names (JIRA_URL / JIRA_USERNAME / JIRA_API_TOKEN?).
+      - name: jira
+        source: jira:${JIRA_PROJECT}
+        kb-id: ${KB_JIRA_ID}
+        token: ${JIRA_TOKEN}
+
+      # Discord.
+      # TODO: confirm exact env-var names and scope syntax (bot token / channel).
+      - name: discord
+        source: discord:${DISCORD_SCOPE}
+        kb-id: ${KB_DISCORD_ID}
+        token: ${DISCORD_TOKEN}
+
+      # Slack.
+      # TODO: confirm exact env-var names and scope syntax (app token / channel).
+      - name: slack
+        source: slack:${SLACK_SCOPE}
+        kb-id: ${KB_SLACK_ID}
+        token: ${SLACK_TOKEN}
+
+      # Zotero research library.
+      - name: zotero
+        source: zotero:
+        kb-id: ${KB_ZOTERO_ID}
+
+      # Gmail — deferred. OAuth-heavy (refresh-token flow + oikb[gmail] extra),
+      # not enabled until credentials are provisioned. Uncomment once ready:
+      # - name: gmail
+      #   source: gmail:
+      #   kb-id: ${KB_GMAIL_ID}
+      #   token: ${GMAIL_REFRESH_TOKEN}

--- a/kubernetes/llm/components/knowledge-sync/deployment.yaml
+++ b/kubernetes/llm/components/knowledge-sync/deployment.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: knowledge-sync
+  namespace: llm
+  labels:
+    app.kubernetes.io/name: knowledge-sync
+    app.kubernetes.io/instance: knowledge-sync
+spec:
+  replicas: 1
+  revisionHistoryLimit: 0
+  progressDeadlineSeconds: 600
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: knowledge-sync
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: knowledge-sync
+        app.kubernetes.io/instance: knowledge-sync
+    spec:
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      automountServiceAccountToken: false
+      serviceAccountName: knowledge-sync
+      enableServiceLinks: false
+      dnsPolicy: ClusterFirst
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: knowledge-sync
+          # oikb daemon: incremental multi-source sync into Open WebUI Knowledge
+          # Bases. Sources, schedules, and tokens come from the ConfigMap
+          # (.oikb.yaml) and the ESO Secret (env) mounted below.
+          # renovate: datasource=docker depName=ghcr.io/open-webui/oikb versioning=docker
+          image: ghcr.io/open-webui/oikb:0.4.0@sha256:e61c1beef9fe91d2f00ca8612e847eacc7d579e2e8e258f40fb1ef3e2891e8d4
+          imagePullPolicy: IfNotPresent
+          args:
+            - "daemon"
+            - "--port"
+            - "8080"
+            - "--log-format"
+            - "json"
+          env:
+            - name: OPEN_WEBUI_URL
+              value: http://open-webui.llm.svc.cluster.local:8080
+          envFrom:
+            - secretRef:
+                name: knowledge-sync
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            privileged: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 12
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "100m"
+              memory: 256Mi
+              ephemeral-storage: "512Mi"
+            limits:
+              cpu: "1"
+              memory: 1Gi
+              ephemeral-storage: "2Gi"
+          volumeMounts:
+            - name: config
+              mountPath: /app/.oikb.yaml
+              subPath: .oikb.yaml
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: knowledge-sync-config
+            items:
+              - key: oikb.yaml
+                path: .oikb.yaml
+        - name: tmp
+          emptyDir:
+            sizeLimit: 512Mi

--- a/kubernetes/llm/components/knowledge-sync/kustomization.yaml
+++ b/kubernetes/llm/components/knowledge-sync/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - service-account.yaml
+  - secret.yaml
+  - config-map.yaml
+  - deployment.yaml
+  - service.yaml
+  - network-policy.yaml
+  - pod-monitor.yaml

--- a/kubernetes/llm/components/knowledge-sync/network-policy.yaml
+++ b/kubernetes/llm/components/knowledge-sync/network-policy.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: knowledge-sync
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: knowledge-sync
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: prometheus
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 8080
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: llm
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: open-webui
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+          podSelector:
+            matchLabels:
+              dns.operator.openshift.io/daemonset-dns: default
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: llm
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: open-webui
+      ports:
+        - protocol: TCP
+          port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-internet-egress-knowledge-sync
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app.kubernetes.io/name: knowledge-sync
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: knowledge-sync
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80

--- a/kubernetes/llm/components/knowledge-sync/pod-monitor.yaml
+++ b/kubernetes/llm/components/knowledge-sync/pod-monitor.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: knowledge-sync
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    app.kubernetes.io/instance: open-webui
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: knowledge-sync
+  podMetricsEndpoints:
+    - port: http
+      path: /metrics

--- a/kubernetes/llm/components/knowledge-sync/secret.yaml
+++ b/kubernetes/llm/components/knowledge-sync/secret.yaml
@@ -1,0 +1,195 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: knowledge-sync
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: knowledge-sync
+    template:
+      engineVersion: v2
+      data:
+        OPEN_WEBUI_API_KEY: "{{ .OPEN_WEBUI_API_KEY }}"
+        OIKB_API_KEY: "{{ .OIKB_API_KEY }}"
+        GITHUB_ORG: "{{ .GITHUB_ORG }}"
+        GITHUB_TOKEN: "{{ .GITHUB_TOKEN }}"
+        NEXTCLOUD_URL: "{{ .NEXTCLOUD_URL }}"
+        NEXTCLOUD_USER: "{{ .NEXTCLOUD_USER }}"
+        NEXTCLOUD_PASSWORD: "{{ .NEXTCLOUD_PASSWORD }}"
+        JIRA_PROJECT: "{{ .JIRA_PROJECT }}"
+        JIRA_TOKEN: "{{ .JIRA_TOKEN }}"
+        DISCORD_SCOPE: "{{ .DISCORD_SCOPE }}"
+        DISCORD_TOKEN: "{{ .DISCORD_TOKEN }}"
+        SLACK_SCOPE: "{{ .SLACK_SCOPE }}"
+        SLACK_TOKEN: "{{ .SLACK_TOKEN }}"
+        ZOTERO_LIBRARY_ID: "{{ .ZOTERO_LIBRARY_ID }}"
+        ZOTERO_API_KEY: "{{ .ZOTERO_API_KEY }}"
+        KB_PERSONAL_SITE_ID: "{{ .KB_PERSONAL_SITE_ID }}"
+        KB_HOMELAB_ID: "{{ .KB_HOMELAB_ID }}"
+        KB_DOCUMENTS_ID: "{{ .KB_DOCUMENTS_ID }}"
+        KB_JIRA_ID: "{{ .KB_JIRA_ID }}"
+        KB_DISCORD_ID: "{{ .KB_DISCORD_ID }}"
+        KB_SLACK_ID: "{{ .KB_SLACK_ID }}"
+        KB_ZOTERO_ID: "{{ .KB_ZOTERO_ID }}"
+  data:
+    - secretKey: OPEN_WEBUI_API_KEY
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: api_key
+        metadataPolicy: None
+    - secretKey: OIKB_API_KEY
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: daemon_key
+        metadataPolicy: None
+    - secretKey: GITHUB_ORG
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: github_org
+        metadataPolicy: None
+    - secretKey: GITHUB_TOKEN
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/mcp-github
+        property: token
+        metadataPolicy: None
+    - secretKey: NEXTCLOUD_URL
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: nextcloud_url
+        metadataPolicy: None
+    - secretKey: NEXTCLOUD_USER
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: nextcloud_user
+        metadataPolicy: None
+    - secretKey: NEXTCLOUD_PASSWORD
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: nextcloud_password
+        metadataPolicy: None
+    - secretKey: JIRA_PROJECT
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: jira_project
+        metadataPolicy: None
+    - secretKey: JIRA_TOKEN
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: jira_token
+        metadataPolicy: None
+    - secretKey: DISCORD_SCOPE
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: discord_scope
+        metadataPolicy: None
+    - secretKey: DISCORD_TOKEN
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: discord_token
+        metadataPolicy: None
+    - secretKey: SLACK_SCOPE
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: slack_scope
+        metadataPolicy: None
+    - secretKey: SLACK_TOKEN
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: slack_token
+        metadataPolicy: None
+    - secretKey: ZOTERO_LIBRARY_ID
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: zotero_library_id
+        metadataPolicy: None
+    - secretKey: ZOTERO_API_KEY
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: zotero_api_key
+        metadataPolicy: None
+    - secretKey: KB_PERSONAL_SITE_ID
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: kb_personal_site
+        metadataPolicy: None
+    - secretKey: KB_HOMELAB_ID
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: kb_homelab
+        metadataPolicy: None
+    - secretKey: KB_DOCUMENTS_ID
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: kb_documents
+        metadataPolicy: None
+    - secretKey: KB_JIRA_ID
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: kb_jira
+        metadataPolicy: None
+    - secretKey: KB_DISCORD_ID
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: kb_discord
+        metadataPolicy: None
+    - secretKey: KB_SLACK_ID
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: kb_slack
+        metadataPolicy: None
+    - secretKey: KB_ZOTERO_ID
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: kb_zotero
+        metadataPolicy: None

--- a/kubernetes/llm/components/knowledge-sync/service-account.yaml
+++ b/kubernetes/llm/components/knowledge-sync/service-account.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: knowledge-sync
+  namespace: llm
+  labels:
+    app.kubernetes.io/name: knowledge-sync
+    app.kubernetes.io/instance: knowledge-sync

--- a/kubernetes/llm/components/knowledge-sync/service.yaml
+++ b/kubernetes/llm/components/knowledge-sync/service.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: knowledge-sync
+  namespace: llm
+  labels:
+    app.kubernetes.io/name: knowledge-sync
+    app.kubernetes.io/instance: knowledge-sync
+spec:
+  ipFamilies:
+    - IPv4
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: http
+  internalTrafficPolicy: Cluster
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  sessionAffinity: None
+  selector:
+    app.kubernetes.io/name: knowledge-sync

--- a/kubernetes/llm/components/open-webui/deployment.yaml
+++ b/kubernetes/llm/components/open-webui/deployment.yaml
@@ -217,6 +217,46 @@ spec:
             - name: SUBAGENTS_MAX_ITERATIONS
               value: "15"
             - name: SUBAGENTS_MAX_OUTPUT
+            # ---- Observability (Phase 0) ----
+            - name: ENABLE_OTEL
+              value: "true"
+            - name: ENABLE_OTEL_METRICS
+              value: "true"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://open-webui-collector.llm.svc.cluster.local:4317
+            - name: OTEL_EXPORTER_OTLP_INSECURE
+              value: "true"
+            - name: OTEL_SERVICE_NAME
+              value: open-webui
+            - name: ENABLE_AUDIT_STDOUT
+              value: "true"
+            - name: AUDIT_LOG_LEVEL
+              value: REQUEST_RESPONSE
+            - name: ENABLE_CODE_INTERPRETER
+              value: "true"
+            - name: CODE_INTERPRETER_ENGINE
+              value: pyodide
+            - name: USER_PERMISSIONS_FEATURES_CODE_INTERPRETER
+              value: "true"
+            - name: ENABLE_MEMORY_SYSTEM_CONTEXT
+              value: "true"
+            - name: DEFAULT_USER_ROLE
+              value: pending
+            - name: ENABLE_OAUTH_ROLE_MANAGEMENT
+              value: "true"
+            - name: OAUTH_ROLES_CLAIM
+              value: roles
+            - name: OAUTH_ALLOWED_ROLES
+              value: user,admin
+            - name: OAUTH_ADMIN_ROLES
+              value: admin
+            - name: ENABLE_EVALUATION_ARENA_MODELS
+              value: "true"
+            - name: TOOL_SERVER_CONNECTIONS
+              valueFrom:
+                secretKeyRef:
+                  name: open-webui-config
+                  key: TOOL_SERVER_CONNECTIONS
               value: "8000"
           securityContext:
             runAsNonRoot: true

--- a/kubernetes/llm/components/open-webui/secret.yaml
+++ b/kubernetes/llm/components/open-webui/secret.yaml
@@ -5,7 +5,6 @@ metadata:
   name: open-webui-config
   namespace: llm
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   refreshInterval: "1h"
@@ -14,6 +13,38 @@ spec:
     kind: ClusterSecretStore
   target:
     name: open-webui-config
+    template:
+      engineVersion: v2
+      data:
+        WEBUI_SECRET_KEY: "{{ .WEBUI_SECRET_KEY }}"
+        OAUTH_CLIENT_ID: "{{ .OAUTH_CLIENT_ID }}"
+        OAUTH_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
+        TOOL_SERVER_CONNECTIONS: |-
+          [
+            {
+              "url": "http://mcp-kubernetes.llm.svc.cluster.local:8080",
+              "path": "mcp",
+              "type": "mcp",
+              "auth_type": "none",
+              "info": {"name": "Kubernetes (read-only)", "description": "Inspect the OKD cluster: get/list/watch only."}
+            },
+            {
+              "url": "http://mcp-github.llm.svc.cluster.local:8080",
+              "path": "mcp",
+              "type": "mcp",
+              "auth_type": "bearer",
+              "key": "{{ .GITHUB_PAT }}",
+              "info": {"name": "GitHub (read-only)", "description": "Query repos, issues, and pull requests."}
+            },
+            {
+              "url": "http://knowledge-sync.llm.svc.cluster.local:8080",
+              "path": "",
+              "type": "openapi",
+              "auth_type": "bearer",
+              "key": "{{ .OIKB_API_KEY }}",
+              "info": {"name": "Knowledge Sync (oikb)", "description": "Trigger Open WebUI Knowledge Base syncs, check status, and query history."}
+            }
+          ]
   data:
     - secretKey: WEBUI_SECRET_KEY
       remoteRef:
@@ -35,4 +66,18 @@ spec:
         decodingStrategy: None
         key: homelab/llm/open-webui/zitadel
         property: client_secret
+        metadataPolicy: None
+    - secretKey: GITHUB_PAT
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/mcp-github
+        property: token
+        metadataPolicy: None
+    - secretKey: OIKB_API_KEY
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: homelab/llm/knowledge-sync
+        property: daemon_key
         metadataPolicy: None

--- a/kubernetes/llm/components/otel-collector/collector.yaml
+++ b/kubernetes/llm/components/otel-collector/collector.yaml
@@ -1,0 +1,76 @@
+---
+# Managed by the community OpenTelemetry Operator (kubernetes/opentelemetry-operator).
+#
+# Open WebUI v0.11.0 has NO scrapeable /metrics endpoint; it only PUSHES OTLP.
+# This collector receives OTLP on :4317/:4318 and re-exposes a scrapeable
+# Prometheus endpoint on :9464 (metrics namespaced "openwebui") that the
+# hand-rolled Prometheus (static_configs) scrapes.
+#
+# The operator renders the Deployment + Service ("open-webui-collector") from
+# this CR. Requires the OpenTelemetryCollector CRD, which is third-party (not a
+# cluster built-in), so the sync-option below is required for first sync.
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: open-webui
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/instance: otel-collector
+spec:
+  mode: deployment
+  replicas: 1
+  ports:
+    - name: prometheus
+      port: 9464
+      targetPort: 9464
+      protocol: TCP
+  resources:
+    requests:
+      cpu: "25m"
+      memory: 128Mi
+    limits:
+      cpu: "250m"
+      memory: 512Mi
+  securityContext:
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    privileged: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+        - ALL
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      batch:
+        timeout: 10s
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:9464
+        namespace: openwebui
+        resource_to_telemetry_conversion:
+          enabled: true
+    service:
+      telemetry:
+        metrics:
+          level: none
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]

--- a/kubernetes/llm/components/otel-collector/kustomization.yaml
+++ b/kubernetes/llm/components/otel-collector/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - collector.yaml
+  - network-policy.yaml

--- a/kubernetes/llm/components/otel-collector/network-policy.yaml
+++ b/kubernetes/llm/components/otel-collector/network-policy.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: otel-collector
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/instance: llm.open-webui
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: llm
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: open-webui
+      ports:
+        - protocol: TCP
+          port: 4317
+        - protocol: TCP
+          port: 4318
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: prometheus
+      ports:
+        - protocol: TCP
+          port: 9464
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+          podSelector:
+            matchLabels:
+              dns.operator.openshift.io/daemonset-dns: default
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353

--- a/kubernetes/llm/overlays/okd/kustomization.yaml
+++ b/kubernetes/llm/overlays/okd/kustomization.yaml
@@ -18,3 +18,5 @@ components:
   - ../../components/litellm-gateway
   - ../../components/llama-swap-gateway
   - ../../components/searxng
+  - ../../components/otel-collector
+  - ../../components/knowledge-sync

--- a/kubernetes/opentelemetry-operator/base/installplan-approver.yaml
+++ b/kubernetes/opentelemetry-operator/base/installplan-approver.yaml
@@ -1,0 +1,139 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: installplan-approvers
+  namespace: opentelemetry-operator
+  labels:
+    app.kubernetes.io/instance: opentelemetry-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: installplan-approver
+subjects:
+  - kind: ServiceAccount
+    name: installplan-approver-job
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: installplan-approver-job
+  namespace: opentelemetry-operator
+  labels:
+    app.kubernetes.io/instance: opentelemetry-operator
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: installplan-approver-opentelemetry-operator
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "0"
+    checkov.io/skip1: CKV_K8S_38=Need to Approve Install Plans
+    checkov.io/skip2: CKV_K8S_40=OpenShift Injects Random UID
+    checkov.io/skip3: CKV_K8S_43=Don't Mind Tag for This
+  labels:
+    app.kubernetes.io/instance: opentelemetry-operator
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 500
+  completionMode: NonIndexed
+  suspend: false
+  template:
+    metadata:
+      labels:
+        app: installplan-approver
+    spec:
+      restartPolicy: OnFailure
+      activeDeadlineSeconds: 300
+      serviceAccountName: installplan-approver-job
+      automountServiceAccountToken: true
+      enableServiceLinks: true
+      terminationGracePeriodSeconds: 30
+      schedulerName: default-scheduler
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      dnsPolicy: ClusterFirst
+      containers:
+        - name: installplan-approver
+          imagePullPolicy: IfNotPresent
+          # renovate: datasource=docker depName=registry.arthurvardevanyan.com/homelab/toolbox versioning=loose
+          image: registry.arthurvardevanyan.com/homelab/toolbox:not_latest@sha256:0000000000000000000000000000000000000000000000000000000000000000
+          env:
+            - name: SUBSCRIPTION
+              value: opentelemetry-operator
+            - name: SLEEP
+              value: "15"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: true
+            privileged: false
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -o errexit  # exit on any failure
+              set -o nounset  # exit on undeclared variables
+              set -o pipefail # return value of all commands in a pipe
+
+              echo "Approving Operator Install. Waiting a few seconds to make sure the InstallPlan gets Created First."
+              sleep "${SLEEP}"
+
+              echo "Processing subscription '${SUBSCRIPTION}'"
+              export INSTALL_PLAN
+              export STARTING_CSV
+              export INSTALL_PLAN_VERSION
+              export INSTALL_CSV
+
+              INSTALLED_CSV=$(kubectl -n "${NAMESPACE}" get subscriptions.operators.coreos.com --field-selector metadata.name="${SUBSCRIPTION}" -o jsonpath='{.items[0].status.installedCSV}')
+              STARTING_CSV=$(kubectl -n "${NAMESPACE}" get subscriptions.operators.coreos.com --field-selector metadata.name="${SUBSCRIPTION}" -o jsonpath='{.items[0].spec.startingCSV}')
+              echo Installed CSV: "${INSTALLED_CSV}"
+              echo Starting CSV: "${STARTING_CSV}"
+
+              # If Installed (Current) Version equals Starting (Target) Version then Exit
+              if [[ "${INSTALLED_CSV}" == "${STARTING_CSV}" ]]; then
+                echo "Installed CSV and Starting CSV Identical, Exiting"
+                exit 0
+              fi
+
+              INSTALL_PLAN=$(kubectl -n "${NAMESPACE}" get subscriptions.operators.coreos.com --field-selector metadata.name="${SUBSCRIPTION}" -o jsonpath='{.items[0].status.installPlanRef.name}')
+              INSTALL_PLAN_VERSION=$(kubectl -n "${NAMESPACE}" get installplan "${INSTALL_PLAN}" -o jsonpath="{.spec.clusterServiceVersionNames}")
+              echo Install Plan CSV: "${INSTALL_PLAN_VERSION}"
+              echo Starting CSV: "${STARTING_CSV}"
+
+              # Check if Install Plan Version Matches Target Version, if not Exit.
+              # Common Cause is due to attempting to skip multiple versions
+              if [[ "${INSTALL_PLAN_VERSION}" != *"${STARTING_CSV}"* ]]; then
+                echo "Install Plan Does Not Match Desired Version, Manual Intervention Might be Required"
+                exit 1
+              fi
+
+              # Approve Install Plan if Not Approved
+              if [[ "$(kubectl -n "${NAMESPACE}" get installplan "${INSTALL_PLAN}" -o jsonpath="{.spec.approved}")" == "false" ]]; then
+                echo "Approving Subscription ${SUBSCRIPTION} with install plan $INSTALL_PLAN"
+                kubectl -n "${NAMESPACE}" patch installplan "${INSTALL_PLAN}" --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
+              else
+                echo "Install Plan '$INSTALL_PLAN' already approved"
+              fi

--- a/kubernetes/opentelemetry-operator/base/kustomization.yaml
+++ b/kubernetes/opentelemetry-operator/base/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./operator-group.yaml
+  - ./subscription.yaml
+  - ./installplan-approver.yaml
+  - ./limit-range.yaml
+  - ./network-policy.yaml

--- a/kubernetes/opentelemetry-operator/base/limit-range.yaml
+++ b/kubernetes/opentelemetry-operator/base/limit-range.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: opentelemetry-operator-lr
+  namespace: opentelemetry-operator
+  labels:
+    app.kubernetes.io/instance: opentelemetry-operator
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: 250m
+        memory: 256Mi
+        ephemeral-storage: 256Mi
+      defaultRequest:
+        cpu: 5m
+        memory: 32Mi
+        ephemeral-storage: 128Mi

--- a/kubernetes/opentelemetry-operator/base/namespace.yaml
+++ b/kubernetes/opentelemetry-operator/base/namespace.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opentelemetry-operator
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    kubernetes.io/metadata.name: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-operator
+    openshift.io/cluster-monitoring: "true"

--- a/kubernetes/opentelemetry-operator/base/network-policy.yaml
+++ b/kubernetes/opentelemetry-operator/base/network-policy.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-all
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-server
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: openshift-kube-apiserver
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-kube-apiserver
+      ports:
+        - protocol: TCP
+          port: 6443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook-ingress
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: openshift-kube-apiserver
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-kube-apiserver
+        - namespaceSelector:
+            matchLabels:
+              policy-group.network.openshift.io/host-network: ""
+      ports:
+        - protocol: TCP
+          port: 9443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-traffic
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  policyTypes:
+    - Egress
+  podSelector: {}
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+          podSelector:
+            matchLabels:
+              dns.operator.openshift.io/daemonset-dns: default
+      ports:
+        - port: 5353
+          protocol: UDP
+        - port: 5353
+          protocol: TCP

--- a/kubernetes/opentelemetry-operator/base/operator-group.yaml
+++ b/kubernetes/opentelemetry-operator/base/operator-group.yaml
@@ -1,0 +1,15 @@
+---
+# All-namespaces watch (no spec.targetNamespaces) so the OpenTelemetryCollector
+# CR can live in the llm namespace next to Open WebUI.
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: opentelemetry-operator
+  namespace: opentelemetry-operator
+  annotations:
+    operatorframework.io/bundle-unpack-min-retry-interval: 30m
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app.kubernetes.io/instance: opentelemetry-operator
+spec:
+  upgradeStrategy: Default

--- a/kubernetes/opentelemetry-operator/base/subscription.yaml
+++ b/kubernetes/opentelemetry-operator/base/subscription.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opentelemetry-operator
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  channel: alpha
+  installPlanApproval: Manual
+  name: opentelemetry-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  # renovate: datasource=github-releases depName=open-telemetry/opentelemetry-operator
+  startingCSV: opentelemetry-operator.v0.152.0
+  config:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+      requests:
+        cpu: 5m
+        memory: 64Mi

--- a/kubernetes/opentelemetry-operator/overlays/okd/egress-firewall.yaml
+++ b/kubernetes/opentelemetry-operator/overlays/okd/egress-firewall.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: k8s.ovn.org/v1
+kind: EgressFirewall
+metadata:
+  name: default
+  namespace: opentelemetry-operator
+spec:
+  egress:
+    # Control Plane
+    - type: Allow
+      to:
+        nodeSelector:
+          matchLabels:
+            node-role.kubernetes.io/control-plane: ""
+    - type: Deny
+      to:
+        cidrSelector: 0.0.0.0/0

--- a/kubernetes/opentelemetry-operator/overlays/okd/kustomization.yaml
+++ b/kubernetes/opentelemetry-operator/overlays/okd/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ./egress-firewall.yaml
+  - ./vpa.yaml

--- a/kubernetes/opentelemetry-operator/overlays/okd/vpa.yaml
+++ b/kubernetes/opentelemetry-operator/overlays/okd/vpa.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: opentelemetry-operator
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: opentelemetry-operator-controller-manager
+  updatePolicy:
+    updateMode: "InPlaceOrRecreate"
+  resourcePolicy:
+    containerPolicies:
+      - containerName: manager
+        minAllowed:
+          cpu: 5m
+          memory: 32Mi
+        maxAllowed:
+          cpu: 100m
+          memory: 256Mi
+        controlledResources:
+          - cpu
+          - memory
+        controlledValues: RequestsOnly

--- a/kubernetes/prometheus/components/prometheus-nas/config-map.yaml
+++ b/kubernetes/prometheus/components/prometheus-nas/config-map.yaml
@@ -482,3 +482,16 @@ data:
         relabel_configs:
         - target_label: cluster
           replacement: okd
+
+      # Open WebUI metrics via OTEL collector (OTLP → Prometheus bridge).
+      - job_name: 'open-webui'
+        scrape_interval: 30s
+        scrape_timeout: 10s
+        static_configs:
+          - targets:
+            - open-webui-collector.llm.svc.cluster.local:9464
+            labels:
+              app: open-webui
+        relabel_configs:
+        - target_label: cluster
+          replacement: okd

--- a/kubernetes/prometheus/components/prometheus/config-map.yaml
+++ b/kubernetes/prometheus/components/prometheus/config-map.yaml
@@ -482,3 +482,16 @@ data:
         relabel_configs:
         - target_label: cluster
           replacement: okd
+
+      # Open WebUI metrics via OTEL collector (OTLP → Prometheus bridge).
+      - job_name: 'open-webui'
+        scrape_interval: 30s
+        scrape_timeout: 10s
+        static_configs:
+          - targets:
+            - open-webui-collector.llm.svc.cluster.local:9464
+            labels:
+              app: open-webui
+        relabel_configs:
+        - target_label: cluster
+          replacement: okd


### PR DESCRIPTION
## PR3/3 — oikb Daemon for Multi-Source Knowledge Sync

Replaces the previous sitemap CronJob with the oikb daemon, which syncs multiple sources into per-source Open WebUI Knowledge Bases via incremental SHA-256 diffing.

**What's included**
- oikb daemon: Deployment + Service + Secret (ESO) + ConfigMap (`.oikb.yaml`) + NetworkPolicy + PodMonitor + ServiceAccount
- **Sources**: personal-site (sitemap), GitHub HomeLab repo, Nextcloud /Documents, Jira, Discord, Slack, Zotero (Gmail scaffolded but disabled)
- KB IDs and connector tokens injected from Vault via `${VAR}` interpolation
- Registered as **OpenAPI tool server** in Open WebUI `TOOL_SERVER_CONNECTIONS` (3rd entry)
- Prometheus metrics on `/metrics` (PodMonitor)

**Merge order**: Merge PR1 → PR2 → this PR.

**Prerequisites**: Vault secrets for knowledge-sync connector tokens, API keys, and KB IDs (`homelab/llm/knowledge-sync`).
