### PR TITLE
feat(opentelemetry-operator): add community OTEL operator app (OLM install)

### DIFF
--- a/kubernetes/argocd/applications/kustomization.yaml
+++ b/kubernetes/argocd/applications/kustomization.yaml
@@ -71,6 +71,7 @@ resources:
   - openshift-logging.yaml
   - openshift-monitoring.yaml
   - openshift-nfd.yaml
+  - opentelemetry-operator.yaml
   - postgres.yaml
   - prometheus.yaml
   - quay.yaml

--- a/kubernetes/argocd/applications/opentelemetry-operator.yaml
+++ b/kubernetes/argocd/applications/opentelemetry-operator.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opentelemetry-operator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    notifications.argoproj.io/subscribe.on-sync-succeeded.gh-cluster: ""
+    notifications.argoproj.io/subscribe.on-sync-failed.gh-cluster: ""
+    notifications.argoproj.io/subscribe.on-sync-status-unknown.gh-cluster: ""
+    notifications.argoproj.io/subscribe.on-health-degraded.gh-cluster: ""
+  labels:
+    app.kubernetes.io/instance: argocd
+spec:
+  destination:
+    namespace: opentelemetry-operator
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: kubernetes/opentelemetry-operator/overlays/okd
+    repoURL: https://git.arthurvardevanyan.com/ArthurVardevanyan/HomeLab
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - ServerSideApply=true
+      - CreateNamespace=true

--- a/kubernetes/opentelemetry-operator/base/installplan-approver.yaml
+++ b/kubernetes/opentelemetry-operator/base/installplan-approver.yaml
@@ -1,0 +1,139 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: installplan-approvers
+  namespace: opentelemetry-operator
+  labels:
+    app.kubernetes.io/instance: opentelemetry-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: installplan-approver
+subjects:
+  - kind: ServiceAccount
+    name: installplan-approver-job
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: installplan-approver-job
+  namespace: opentelemetry-operator
+  labels:
+    app.kubernetes.io/instance: opentelemetry-operator
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: installplan-approver-opentelemetry-operator
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "0"
+    checkov.io/skip1: CKV_K8S_38=Need to Approve Install Plans
+    checkov.io/skip2: CKV_K8S_40=OpenShift Injects Random UID
+    checkov.io/skip3: CKV_K8S_43=Don't Mind Tag for This
+    gitops-ci.k8s.io/exempt-image-checksum: "registry.arthurvardevanyan.com/homelab/toolbox:not_latest"
+  labels:
+    app.kubernetes.io/instance: opentelemetry-operator
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 500
+  completionMode: NonIndexed
+  suspend: false
+  template:
+    metadata:
+      labels:
+        app: installplan-approver
+    spec:
+      restartPolicy: OnFailure
+      activeDeadlineSeconds: 300
+      serviceAccountName: installplan-approver-job
+      automountServiceAccountToken: true
+      enableServiceLinks: true
+      terminationGracePeriodSeconds: 30
+      schedulerName: default-scheduler
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      dnsPolicy: ClusterFirst
+      containers:
+        - name: installplan-approver
+          imagePullPolicy: IfNotPresent
+          image: registry.arthurvardevanyan.com/homelab/toolbox:not_latest
+          env:
+            - name: SUBSCRIPTION
+              value: opentelemetry-operator
+            - name: SLEEP
+              value: "15"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: true
+            privileged: false
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -o errexit  # exit on any failure
+              set -o nounset  # exit on undeclared variables
+              set -o pipefail # return value of all commands in a pipe
+
+              echo "Approving Operator Install. Waiting a few seconds to make sure the InstallPlan gets Created First."
+              sleep "${SLEEP}"
+
+              echo "Processing subscription '${SUBSCRIPTION}'"
+              export INSTALL_PLAN
+              export STARTING_CSV
+              export INSTALL_PLAN_VERSION
+              export INSTALL_CSV
+
+              INSTALLED_CSV=$(kubectl -n "${NAMESPACE}" get subscriptions.operators.coreos.com --field-selector metadata.name="${SUBSCRIPTION}" -o jsonpath='{.items[0].status.installedCSV}')
+              STARTING_CSV=$(kubectl -n "${NAMESPACE}" get subscriptions.operators.coreos.com --field-selector metadata.name="${SUBSCRIPTION}" -o jsonpath='{.items[0].spec.startingCSV}')
+              echo Installed CSV: "${INSTALLED_CSV}"
+              echo Starting CSV: "${STARTING_CSV}"
+
+              # If Installed (Current) Version equals Starting (Target) Version then Exit
+              if [[ "${INSTALLED_CSV}" == "${STARTING_CSV}" ]]; then
+                echo "Installed CSV and Starting CSV Identical, Exiting"
+                exit 0
+              fi
+
+              INSTALL_PLAN=$(kubectl -n "${NAMESPACE}" get subscriptions.operators.coreos.com --field-selector metadata.name="${SUBSCRIPTION}" -o jsonpath='{.items[0].status.installPlanRef.name}')
+              INSTALL_PLAN_VERSION=$(kubectl -n "${NAMESPACE}" get installplan "${INSTALL_PLAN}" -o jsonpath="{.spec.clusterServiceVersionNames}")
+              echo Install Plan CSV: "${INSTALL_PLAN_VERSION}"
+              echo Starting CSV: "${STARTING_CSV}"
+
+              # Check if Install Plan Version Matches Target Version, if not Exit.
+              # Common Cause is due to attempting to skip multiple versions
+              if [[ "${INSTALL_PLAN_VERSION}" != *"${STARTING_CSV}"* ]]; then
+                echo "Install Plan Does Not Match Desired Version, Manual Intervention Might be Required"
+                exit 1
+              fi
+
+              # Approve Install Plan if Not Approved
+              if [[ "$(kubectl -n "${NAMESPACE}" get installplan "${INSTALL_PLAN}" -o jsonpath="{.spec.approved}")" == "false" ]]; then
+                echo "Approving Subscription ${SUBSCRIPTION} with install plan $INSTALL_PLAN"
+                kubectl -n "${NAMESPACE}" patch installplan "${INSTALL_PLAN}" --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
+              else
+                echo "Install Plan '$INSTALL_PLAN' already approved"
+              fi

--- a/kubernetes/opentelemetry-operator/base/kustomization.yaml
+++ b/kubernetes/opentelemetry-operator/base/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./operator-group.yaml
+  - ./subscription.yaml
+  - ./installplan-approver.yaml
+  - ./limit-range.yaml
+  - ./network-policy.yaml

--- a/kubernetes/opentelemetry-operator/base/limit-range.yaml
+++ b/kubernetes/opentelemetry-operator/base/limit-range.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: opentelemetry-operator-lr
+  namespace: opentelemetry-operator
+  labels:
+    app.kubernetes.io/instance: opentelemetry-operator
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: 250m
+        memory: 256Mi
+        ephemeral-storage: 256Mi
+      defaultRequest:
+        cpu: 5m
+        memory: 32Mi
+        ephemeral-storage: 128Mi

--- a/kubernetes/opentelemetry-operator/base/namespace.yaml
+++ b/kubernetes/opentelemetry-operator/base/namespace.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opentelemetry-operator
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    kubernetes.io/metadata.name: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-operator
+    openshift.io/cluster-monitoring: "true"

--- a/kubernetes/opentelemetry-operator/base/network-policy.yaml
+++ b/kubernetes/opentelemetry-operator/base/network-policy.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-all
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-server
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: openshift-kube-apiserver
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-kube-apiserver
+      ports:
+        - protocol: TCP
+          port: 6443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook-ingress
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: openshift-kube-apiserver
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-kube-apiserver
+        - namespaceSelector:
+            matchLabels:
+              policy-group.network.openshift.io/host-network: ""
+      ports:
+        - protocol: TCP
+          port: 9443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-traffic
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  policyTypes:
+    - Egress
+  podSelector: {}
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+          podSelector:
+            matchLabels:
+              dns.operator.openshift.io/daemonset-dns: default
+      ports:
+        - port: 5353
+          protocol: UDP
+        - port: 5353
+          protocol: TCP

--- a/kubernetes/opentelemetry-operator/base/operator-group.yaml
+++ b/kubernetes/opentelemetry-operator/base/operator-group.yaml
@@ -1,0 +1,15 @@
+---
+# All-namespaces watch (no spec.targetNamespaces) so the OpenTelemetryCollector
+# CR can live in the llm namespace next to Open WebUI.
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: opentelemetry-operator
+  namespace: opentelemetry-operator
+  annotations:
+    operatorframework.io/bundle-unpack-min-retry-interval: 30m
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app.kubernetes.io/instance: opentelemetry-operator
+spec:
+  upgradeStrategy: Default

--- a/kubernetes/opentelemetry-operator/base/subscription.yaml
+++ b/kubernetes/opentelemetry-operator/base/subscription.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opentelemetry-operator
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  channel: alpha
+  installPlanApproval: Manual
+  name: opentelemetry-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: opentelemetry-operator.v0.158.0
+  config:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+      requests:
+        cpu: 5m
+        memory: 64Mi

--- a/kubernetes/opentelemetry-operator/overlays/okd/egress-firewall.yaml
+++ b/kubernetes/opentelemetry-operator/overlays/okd/egress-firewall.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: k8s.ovn.org/v1
+kind: EgressFirewall
+metadata:
+  name: default
+  namespace: opentelemetry-operator
+spec:
+  egress:
+    # Control Plane
+    - type: Allow
+      to:
+        nodeSelector:
+          matchLabels:
+            node-role.kubernetes.io/control-plane: ""
+    - type: Deny
+      to:
+        cidrSelector: 0.0.0.0/0

--- a/kubernetes/opentelemetry-operator/overlays/okd/kustomization.yaml
+++ b/kubernetes/opentelemetry-operator/overlays/okd/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ./egress-firewall.yaml
+  - ./vpa.yaml

--- a/kubernetes/opentelemetry-operator/overlays/okd/vpa.yaml
+++ b/kubernetes/opentelemetry-operator/overlays/okd/vpa.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: opentelemetry-operator
+  namespace: opentelemetry-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: opentelemetry-operator-controller-manager
+  updatePolicy:
+    updateMode: "InPlaceOrRecreate"
+  resourcePolicy:
+    containerPolicies:
+      - containerName: manager
+        minAllowed:
+          cpu: 5m
+          memory: 32Mi
+        maxAllowed:
+          cpu: 100m
+          memory: 256Mi
+        controlledResources:
+          - cpu
+          - memory
+        controlledValues: RequestsOnly


### PR DESCRIPTION
## PR1/3 — OpenTelemetry Operator

This PR installs the OpenTelemetry Operator via OLM so that OpenTelemetryCollector CRs can be managed in-cluster.

**What's included**
- `kubernetes/opentelemetry-operator/` — OLM install: Namespace, OperatorGroup, Subscription, InstallPlan approver, NetworkPolicy, LimitRange
- `overlays/okd/` — OKD overlay with egress firewall for registries + VPA
- ArgoCD Application registration (`sync-wave: 1`, `SkipDryRunOnMissingResource`)

**Merge order**: Must be merged **first** (PR1 → PR2 → PR3).

**Prerequisites**: No Vault secrets required — this is operator-only.
