### PR TITLE
feat(llm): add OTEL collector bridge and Open WebUI observability

### DIFF
--- a/kubernetes/argocd/apps/argocd-apps.yaml
+++ b/kubernetes/argocd/apps/argocd-apps.yaml
@@ -157,6 +157,12 @@ spec:
       kinds:
       - Certificate
     - apiGroups:
+      - opentelemetry.io
+      clusters:
+      - '*'
+      kinds:
+      - OpenTelemetryCollector
+    - apiGroups:
       - external-secrets.io
       clusters:
       - '*'

--- a/kubernetes/argocd/base/argocd.yaml
+++ b/kubernetes/argocd/base/argocd.yaml
@@ -563,6 +563,12 @@ spec:
       - VLCluster
       - VMCluster
     - apiGroups:
+      - opentelemetry.io
+      clusters:
+      - '*'
+      kinds:
+      - OpenTelemetryCollector
+    - apiGroups:
       - operators.coreos.com
       clusters:
       - '*'

--- a/kubernetes/grafana/base/dashboards/open-webui.json
+++ b/kubernetes/grafana/base/dashboards/open-webui.json
@@ -344,6 +344,558 @@
       ],
       "title": "Bridge Up",
       "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 101,
+      "panels": [],
+      "title": "User Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of currently active users.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "value": null
+            }
+          ],
+          "unit": "users"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "openwebui_webui_users_active",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Users",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of users active since midnight today.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "value": null
+            }
+          ],
+          "unit": "users"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "openwebui_webui_users_active_today",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Users Today",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total number of registered users.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "value": null
+            }
+          ],
+          "unit": "users"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "openwebui_webui_users_total",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Users",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 102,
+      "panels": [],
+      "title": "Request Counters",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total cumulative requests by route.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_route) (openwebui_http_server_requests_total)",
+          "legendFormat": "{{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Requests by Route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Requests by HTTP method.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_method) (rate(openwebui_http_server_requests_total[5m]))",
+          "legendFormat": "{{http_method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests by Method",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 103,
+      "panels": [],
+      "title": "Latency Breakdown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "p50 and p90 latency by route.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, http_route) (rate(openwebui_http_server_duration_milliseconds_bucket[5m])))",
+          "legendFormat": "p50 {{http_route}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (le, http_route) (rate(openwebui_http_server_duration_milliseconds_bucket[5m])))",
+          "legendFormat": "p90 {{http_route}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Latency (p50/p90) by Route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "GET vs POST latency comparison.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, http_method) (rate(openwebui_http_server_duration_milliseconds_bucket[5m])))",
+          "legendFormat": "{{http_method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GET vs POST Latency (p95)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 104,
+      "panels": [],
+      "title": "Error Rate Breakdown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "4xx error rate by route.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_route) (rate(openwebui_http_server_duration_milliseconds_count{http_status_code=~\"4..\"}[5m]))",
+          "legendFormat": "{{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "4xx Error Rate by Route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5xx error rate by route.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_route) (rate(openwebui_http_server_duration_milliseconds_count{http_status_code=~\"5..\"}[5m]))",
+          "legendFormat": "{{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "5xx Error Rate by Route",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/kubernetes/grafana/base/dashboards/open-webui.json
+++ b/kubernetes/grafana/base/dashboards/open-webui.json
@@ -1,0 +1,382 @@
+{
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.4.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Open WebUI usage & request metrics exported via the OTEL collector bridge (openwebui_ prefix).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "HTTP request rate served by Open WebUI.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_route) (rate(openwebui_http_server_duration_milliseconds_count[5m]))",
+          "legendFormat": "{{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "p95 request latency.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, http_route) (rate(openwebui_http_server_duration_milliseconds_bucket[5m])))",
+          "legendFormat": "{{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request Latency (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total requests served (all routes).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "value": null
+            }
+          ],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(openwebui_http_server_duration_milliseconds_count[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Request Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5xx error rate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "value": null
+            },
+            {
+              "color": "red",
+              "value": 0.1
+            }
+          ],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(openwebui_http_server_duration_milliseconds_count{http_status_code=~\"5..\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "5xx Error Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Collector uptime — non-zero confirms the OTLP bridge is receiving data.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "value": null
+            },
+            {
+              "color": "green",
+              "value": 1
+            }
+          ],
+          "unit": "bool"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(openwebui_http_server_duration_milliseconds_count) > bool 0",
+          "refId": "A"
+        }
+      ],
+      "title": "Bridge Up",
+      "type": "stat"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["open-webui", "llm"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Prometheus",
+          "value": "Prometheus",
+          "selected": true
+        },
+        "hide": 0,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Open WebUI",
+  "uid": "open-webui",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/grafana/base/kustomization.yaml
+++ b/kubernetes/grafana/base/kustomization.yaml
@@ -28,6 +28,7 @@ configMapGenerator:
       - dashboards/loki.json
       - dashboards/node-exporter.json
       - dashboards/ntp.json
+      - dashboards/open-webui.json
       - dashboards/pfsense_lite.json
       - dashboards/version-checker.json
     name: grafana-dashboards

--- a/kubernetes/llm/README.md
+++ b/kubernetes/llm/README.md
@@ -117,13 +117,13 @@ and both llama-swap endpoints) share a single combined `llm` job, with
 - job_name: "llm"
   scrape_interval: 30s
   static_configs:
-    - targets: ["xpumd.intel-device-plugins-operator.svc.cluster.local:8080"]
+    - targets: ["xpumd.intel-device-plugins-operator.svc.cluster.local.:8080"]
       labels: { app: intel-gpu }
-    - targets: ["litellm-svc.llm.svc.cluster.local:4000"]
+    - targets: ["litellm-svc.llm.svc.cluster.local.:4000"]
       labels: { app: litellm }
-    - targets: ["llama-swap-svc.llm.svc.cluster.local:8080"]
+    - targets: ["llama-swap-svc.llm.svc.cluster.local.:8080"]
       labels: { app: llama-swap }
-    - targets: ["llama-swap-svc.llm.svc.cluster.local:9100"]
+    - targets: ["llama-swap-svc.llm.svc.cluster.local.:9100"]
       labels: { app: llama-swap }
 ```
 

--- a/kubernetes/llm/base/network-policy.yaml
+++ b/kubernetes/llm/base/network-policy.yaml
@@ -48,6 +48,8 @@ spec:
           port: 11434
         - protocol: TCP
           port: 9187
+        - protocol: TCP
+          port: 9464
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -89,13 +91,13 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              name: openshift-monitoring
+              kubernetes.io/metadata.name: openshift-monitoring
           podSelector:
             matchLabels:
               app.kubernetes.io/name: prometheus
         - namespaceSelector:
             matchLabels:
-              name: openshift-user-workload-monitoring
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
           podSelector:
             matchLabels:
               app.kubernetes.io/name: prometheus
@@ -110,3 +112,5 @@ spec:
           port: 11434
         - protocol: TCP
           port: 9187
+        - protocol: TCP
+          port: 9464

--- a/kubernetes/llm/components/litellm-gateway/probe.yaml
+++ b/kubernetes/llm/components/litellm-gateway/probe.yaml
@@ -12,7 +12,7 @@ spec:
   module: http_2xx
   prober:
     path: /probe
-    url: blackbox-exporter.blackbox-exporter.svc.cluster.local:9115
+    url: blackbox-exporter.blackbox-exporter.svc.cluster.local.:9115
   targets:
     staticConfig:
       static:

--- a/kubernetes/llm/components/litellm/README.md
+++ b/kubernetes/llm/components/litellm/README.md
@@ -65,7 +65,7 @@ Four model names are exposed to clients: three with two deployments (one per GPU
 | `qwen3.8-27b`            | `openai/27b-gpu1`       | `openai/27b-gpu0`       | 1.3e-8           | 1.3e-8            |
 | `qwen3.6-35b-a3b-spread` | `openai/35b-spread`     | —                       | 0.8e-8           | 0.8e-8            |
 
-All deployments point to `http://llama-swap-svc.llm.svc.cluster.local:8080/v1`
+All deployments point to `http://llama-swap-svc.llm.svc.cluster.local.:8080/v1`
 with `api_key: "dummy"`. Cost tracking is enabled via `SPEND_TRACKING: "true"`
 and `store_prompts_in_spend_logs: true` — token usage is stored in the CNPG
 PostgreSQL database.
@@ -192,7 +192,7 @@ circuit as the LLM system (gpu-1 node) for accurate readings.
 
 ### Response & cache
 
-LiteLLM uses **Dragonfly** (`litellm-dragonfly.llm.svc.cluster.local:6379`) as
+LiteLLM uses **Dragonfly** (`litellm-dragonfly.llm.svc.cluster.local.:6379`) as
 a Redis-compatible cache backend:
 
 - **Response caching**: `cache: true` with `ttl: 86400` (24 hours), namespace
@@ -332,7 +332,7 @@ proxy. All state (cache, sessions, cost tracking) is external:
 LiteLLM uses PostgreSQL for cost tracking, spend logs, and session data,
 deployed via CloudNativePG (`components/cnpg-litellm/`):
 
-- **Connection**: `postgresql://postgres@litellm-rw.llm.svc.cluster.local:5432/litellm`
+- **Connection**: `postgresql://postgres@litellm-rw.llm.svc.cluster.local.:5432/litellm`
   (via the CNPG read-write service).
 - **`STORE_MODEL_IN_DB: false`**: models are defined in `litellm.yaml`, not
   fetched from the database.

--- a/kubernetes/llm/components/litellm/deployment.yaml
+++ b/kubernetes/llm/components/litellm/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - name: STORE_MODEL_IN_DB
               value: "false"
             - name: LLAMA_SWAP_BASE_URL
-              value: http://llama-swap-svc.llm.svc.cluster.local:8080
+              value: http://llama-swap-svc.llm.svc.cluster.local.:8080
             - name: LLAMA_SWAP_PIN_REDIS_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/llm/components/litellm/litellm.yaml
+++ b/kubernetes/llm/components/litellm/litellm.yaml
@@ -4,14 +4,14 @@ model_list:
   - model_name: qwen3.6-35b-a3b
     litellm_params:
       model: openai/35b-gpu0
-      api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
+      api_base: http://llama-swap-svc.llm.svc.cluster.local.:8080/v1
       api_key: "dummy"
       input_cost_per_token: 0.000000013
       output_cost_per_token: 0.000000013
   - model_name: qwen3.6-35b-a3b
     litellm_params:
       model: openai/35b-gpu1
-      api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
+      api_base: http://llama-swap-svc.llm.svc.cluster.local.:8080/v1
       api_key: "dummy"
       input_cost_per_token: 0.000000013
       output_cost_per_token: 0.000000013
@@ -19,14 +19,14 @@ model_list:
   - model_name: qwen3.6-35b-a3b-dense
     litellm_params:
       model: openai/35b-gpu0-dense
-      api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
+      api_base: http://llama-swap-svc.llm.svc.cluster.local.:8080/v1
       api_key: "dummy"
       input_cost_per_token: 0.000000013
       output_cost_per_token: 0.000000013
   - model_name: qwen3.6-35b-a3b-dense
     litellm_params:
       model: openai/35b-gpu1-dense
-      api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
+      api_base: http://llama-swap-svc.llm.svc.cluster.local.:8080/v1
       api_key: "dummy"
       input_cost_per_token: 0.000000013
       output_cost_per_token: 0.000000013
@@ -35,14 +35,14 @@ model_list:
   - model_name: qwen3.8-27b
     litellm_params:
       model: openai/27b-gpu1
-      api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
+      api_base: http://llama-swap-svc.llm.svc.cluster.local.:8080/v1
       api_key: "dummy"
       input_cost_per_token: 0.000000013
       output_cost_per_token: 0.000000013
   - model_name: qwen3.8-27b
     litellm_params:
       model: openai/27b-gpu0
-      api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
+      api_base: http://llama-swap-svc.llm.svc.cluster.local.:8080/v1
       api_key: "dummy"
       input_cost_per_token: 0.000000013
       output_cost_per_token: 0.000000013
@@ -51,7 +51,7 @@ model_list:
   - model_name: qwen3.6-35b-a3b-spread
     litellm_params:
       model: openai/35b-spread
-      api_base: http://llama-swap-svc.llm.svc.cluster.local:8080/v1
+      api_base: http://llama-swap-svc.llm.svc.cluster.local.:8080/v1
       api_key: "dummy"
       input_cost_per_token: 0.000000008
       output_cost_per_token: 0.000000008

--- a/kubernetes/llm/components/litellm/llama_swap_affinity.py
+++ b/kubernetes/llm/components/litellm/llama_swap_affinity.py
@@ -96,7 +96,7 @@ logger = logging.getLogger(__name__)
 
 # llama-swap HTTP client settings
 _LLAMA_SWAP_BASE_URL: Final = os.environ.get(
-    "LLAMA_SWAP_BASE_URL", "http://llama-swap-svc.llm.svc.cluster.local:8080"
+    "LLAMA_SWAP_BASE_URL", "http://llama-swap-svc.llm.svc.cluster.local.:8080"
 ).rstrip("/")
 _RUNNING_URL: Final = f"{_LLAMA_SWAP_BASE_URL}/running"
 

--- a/kubernetes/llm/components/llama-swap-gateway/probe.yaml
+++ b/kubernetes/llm/components/llama-swap-gateway/probe.yaml
@@ -12,7 +12,7 @@ spec:
   module: http_2xx
   prober:
     path: /probe
-    url: blackbox-exporter.blackbox-exporter.svc.cluster.local:9115
+    url: blackbox-exporter.blackbox-exporter.svc.cluster.local.:9115
   targets:
     staticConfig:
       static:

--- a/kubernetes/llm/components/open-webui-gateway/probe.yaml
+++ b/kubernetes/llm/components/open-webui-gateway/probe.yaml
@@ -12,7 +12,7 @@ spec:
   module: http_2xx
   prober:
     path: /probe
-    url: blackbox-exporter.blackbox-exporter.svc.cluster.local:9115
+    url: blackbox-exporter.blackbox-exporter.svc.cluster.local.:9115
   targets:
     staticConfig:
       static:

--- a/kubernetes/llm/components/open-webui/deployment.yaml
+++ b/kubernetes/llm/components/open-webui/deployment.yaml
@@ -218,6 +218,17 @@ spec:
               value: "15"
             - name: SUBAGENTS_MAX_OUTPUT
               value: "8000"
+            # ---- Observability (OTEL) ----
+            - name: ENABLE_OTEL
+              value: "true"
+            - name: ENABLE_OTEL_METRICS
+              value: "true"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://open-webui-collector.llm.svc.cluster.local:4317
+            - name: OTEL_EXPORTER_OTLP_INSECURE
+              value: "true"
+            - name: OTEL_SERVICE_NAME
+              value: open-webui
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true

--- a/kubernetes/llm/components/open-webui/deployment.yaml
+++ b/kubernetes/llm/components/open-webui/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - /app/backend/start.sh
           env:
             - name: OPENAI_API_BASE_URL
-              value: http://litellm-svc.llm.svc.cluster.local:4000/v1
+              value: http://litellm-svc.llm.svc.cluster.local.:4000/v1
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -193,7 +193,7 @@ spec:
             - name: RAG_EMBEDDING_MODEL
               value: nomic-embed-text-v1.5
             - name: RAG_OPENAI_API_BASE_URL
-              value: http://llm-embed-svc.llm.svc.cluster.local:11435/v1
+              value: http://llm-embed-svc.llm.svc.cluster.local.:11435/v1
             - name: RAG_OPENAI_API_KEY
               value: sk-noauth
             - name: VECTOR_DB
@@ -224,7 +224,7 @@ spec:
             - name: ENABLE_OTEL_METRICS
               value: "true"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://open-webui-collector.llm.svc.cluster.local:4317
+              value: http://open-webui-collector.llm.svc.cluster.local.:4317
             - name: OTEL_EXPORTER_OTLP_INSECURE
               value: "true"
             - name: OTEL_SERVICE_NAME

--- a/kubernetes/llm/components/open-webui/network-policy.yaml
+++ b/kubernetes/llm/components/open-webui/network-policy.yaml
@@ -86,6 +86,18 @@ spec:
     - to:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: llm
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opentelemetry-collector
+      ports:
+        - protocol: TCP
+          port: 4317
+        - protocol: TCP
+          port: 4318
+    - to:
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: openshift-dns
           podSelector:
             matchLabels:

--- a/kubernetes/llm/components/open-webui/secret.yaml
+++ b/kubernetes/llm/components/open-webui/secret.yaml
@@ -5,7 +5,6 @@ metadata:
   name: open-webui-config
   namespace: llm
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   refreshInterval: "1h"
@@ -14,6 +13,12 @@ spec:
     kind: ClusterSecretStore
   target:
     name: open-webui-config
+    template:
+      engineVersion: v2
+      data:
+        WEBUI_SECRET_KEY: "{{ .WEBUI_SECRET_KEY }}"
+        OAUTH_CLIENT_ID: "{{ .OAUTH_CLIENT_ID }}"
+        OAUTH_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
   data:
     - secretKey: WEBUI_SECRET_KEY
       remoteRef:

--- a/kubernetes/llm/components/otel-collector/collector.yaml
+++ b/kubernetes/llm/components/otel-collector/collector.yaml
@@ -1,0 +1,76 @@
+---
+# Managed by the community OpenTelemetry Operator (kubernetes/opentelemetry-operator).
+#
+# Open WebUI v0.11.0 has NO scrapeable /metrics endpoint; it only PUSHES OTLP.
+# This collector receives OTLP on :4317/:4318 and re-exposes a scrapeable
+# Prometheus endpoint on :9464 (metrics namespaced "openwebui") that the
+# hand-rolled Prometheus (static_configs) scrapes.
+#
+# The operator renders the Deployment + Service ("open-webui-collector") from
+# this CR. Requires the OpenTelemetryCollector CRD, which is third-party (not a
+# cluster built-in), so the sync-option below is required for first sync.
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: open-webui
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/instance: otel-collector
+spec:
+  mode: deployment
+  replicas: 1
+  ports:
+    - name: prometheus
+      port: 9464
+      targetPort: 9464
+      protocol: TCP
+  resources:
+    requests:
+      cpu: "25m"
+      memory: 128Mi
+    limits:
+      cpu: "250m"
+      memory: 512Mi
+  securityContext:
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    privileged: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+        - ALL
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      batch:
+        timeout: 10s
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:9464
+        namespace: openwebui
+        resource_to_telemetry_conversion:
+          enabled: true
+    service:
+      telemetry:
+        metrics:
+          level: none
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]

--- a/kubernetes/llm/components/otel-collector/collector.yaml
+++ b/kubernetes/llm/components/otel-collector/collector.yaml
@@ -22,6 +22,12 @@ metadata:
 spec:
   mode: deployment
   replicas: 1
+  nodeSelector:
+    node-role.kubernetes.io/gpu: ""
+  tolerations:
+    - key: node-role.kubernetes.io/gpu
+      operator: Exists
+      effect: NoSchedule
   ports:
     - name: prometheus
       port: 9464

--- a/kubernetes/llm/components/otel-collector/kustomization.yaml
+++ b/kubernetes/llm/components/otel-collector/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Component
 resources:
   - collector.yaml
   - network-policy.yaml
-
+  - service-monitor.yaml
   - vpa.yaml

--- a/kubernetes/llm/components/otel-collector/kustomization.yaml
+++ b/kubernetes/llm/components/otel-collector/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Component
 resources:
   - collector.yaml
   - network-policy.yaml
+
+  - vpa.yaml

--- a/kubernetes/llm/components/otel-collector/kustomization.yaml
+++ b/kubernetes/llm/components/otel-collector/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - collector.yaml
+  - network-policy.yaml

--- a/kubernetes/llm/components/otel-collector/network-policy.yaml
+++ b/kubernetes/llm/components/otel-collector/network-policy.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: otel-collector
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/instance: llm.open-webui
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: llm
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: open-webui
+      ports:
+        - protocol: TCP
+          port: 4317
+        - protocol: TCP
+          port: 4318
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: prometheus
+      ports:
+        - protocol: TCP
+          port: 9464
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+          podSelector:
+            matchLabels:
+              dns.operator.openshift.io/daemonset-dns: default
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353

--- a/kubernetes/llm/components/otel-collector/service-monitor.yaml
+++ b/kubernetes/llm/components/otel-collector/service-monitor.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: open-webui-collector
+  namespace: llm
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/instance: otel-collector
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector
+      app.kubernetes.io/instance: llm.open-webui
+  endpoints:
+    - port: prometheus
+      interval: 30s
+      path: /metrics
+      honorLabels: true

--- a/kubernetes/llm/components/otel-collector/vpa.yaml
+++ b/kubernetes/llm/components/otel-collector/vpa.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: open-webui-collector
+  namespace: llm
+spec:
+  targetRef:
+    apiVersion: opentelemetry.io/v1alpha1
+    kind: OpenTelemetryCollector
+    name: open-webui-collector
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+      - containerName: opentelemetry-collector
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "1"
+          memory: 512Mi

--- a/kubernetes/llm/components/otel-collector/vpa.yaml
+++ b/kubernetes/llm/components/otel-collector/vpa.yaml
@@ -4,19 +4,25 @@ kind: VerticalPodAutoscaler
 metadata:
   name: open-webui-collector
   namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   targetRef:
     apiVersion: opentelemetry.io/v1alpha1
     kind: OpenTelemetryCollector
     name: open-webui-collector
   updatePolicy:
-    updateMode: Auto
+    updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
       - containerName: opentelemetry-collector
         minAllowed:
-          cpu: 50m
-          memory: 64Mi
+          cpu: 5m
+          memory: 32Mi
         maxAllowed:
-          cpu: "1"
+          cpu: "250m"
           memory: 512Mi
+        controlledResources:
+          - cpu
+          - memory
+        controlledValues: RequestsOnly

--- a/kubernetes/llm/overlays/okd/kustomization.yaml
+++ b/kubernetes/llm/overlays/okd/kustomization.yaml
@@ -19,3 +19,4 @@ components:
   - ../../components/llama-swap-gateway
   - ../../components/searxng
   - ../../components/otel-collector
+  - ../../components/knowledge-sync

--- a/kubernetes/llm/overlays/okd/kustomization.yaml
+++ b/kubernetes/llm/overlays/okd/kustomization.yaml
@@ -19,4 +19,3 @@ components:
   - ../../components/llama-swap-gateway
   - ../../components/searxng
   - ../../components/otel-collector
-  - ../../components/knowledge-sync

--- a/kubernetes/llm/overlays/okd/kustomization.yaml
+++ b/kubernetes/llm/overlays/okd/kustomization.yaml
@@ -18,3 +18,4 @@ components:
   - ../../components/litellm-gateway
   - ../../components/llama-swap-gateway
   - ../../components/searxng
+  - ../../components/otel-collector

--- a/kubernetes/prometheus/components/prometheus-nas/config-map.yaml
+++ b/kubernetes/prometheus/components/prometheus-nas/config-map.yaml
@@ -482,3 +482,16 @@ data:
         relabel_configs:
         - target_label: cluster
           replacement: okd
+
+      # Open WebUI metrics via OTEL collector (OTLP → Prometheus bridge).
+      - job_name: 'open-webui'
+        scrape_interval: 30s
+        scrape_timeout: 10s
+        static_configs:
+          - targets:
+            - open-webui-collector.llm.svc.cluster.local:9464
+            labels:
+              app: open-webui
+        relabel_configs:
+        - target_label: cluster
+          replacement: okd

--- a/kubernetes/prometheus/components/prometheus-nas/config-map.yaml
+++ b/kubernetes/prometheus/components/prometheus-nas/config-map.yaml
@@ -455,21 +455,25 @@ data:
 
         static_configs:
           - targets:
-            - xpumd.intel-device-plugins-operator.svc.cluster.local:8080
+            - xpumd.intel-device-plugins-operator.svc.cluster.local.:8080
             labels:
               app: intel-gpu
           - targets:
-            - litellm-svc.llm.svc.cluster.local:4000
+            - litellm-svc.llm.svc.cluster.local.:4000
             labels:
               app: litellm
           - targets:
-            - llama-swap-svc.llm.svc.cluster.local:8080
+            - llama-swap-svc.llm.svc.cluster.local.:8080
             labels:
               app: llama-swap
           - targets:
-            - llama-swap-svc.llm.svc.cluster.local:9100
+            - llama-swap-svc.llm.svc.cluster.local.:9100
             labels:
               app: llama-swap
+          - targets:
+            - open-webui-collector.llm.svc.cluster.local.:9464
+            labels:
+              app: open-webui
 
         metric_relabel_configs:
         - source_labels: [ __name__ ]
@@ -479,19 +483,6 @@ data:
           regex: 'process_(.+)'
           action: drop
 
-        relabel_configs:
-        - target_label: cluster
-          replacement: okd
-
-      # Open WebUI metrics via OTEL collector (OTLP → Prometheus bridge).
-      - job_name: 'open-webui'
-        scrape_interval: 30s
-        scrape_timeout: 10s
-        static_configs:
-          - targets:
-            - open-webui-collector.llm.svc.cluster.local:9464
-            labels:
-              app: open-webui
         relabel_configs:
         - target_label: cluster
           replacement: okd

--- a/kubernetes/prometheus/components/prometheus/config-map.yaml
+++ b/kubernetes/prometheus/components/prometheus/config-map.yaml
@@ -482,3 +482,16 @@ data:
         relabel_configs:
         - target_label: cluster
           replacement: okd
+
+      # Open WebUI metrics via OTEL collector (OTLP → Prometheus bridge).
+      - job_name: 'open-webui'
+        scrape_interval: 30s
+        scrape_timeout: 10s
+        static_configs:
+          - targets:
+            - open-webui-collector.llm.svc.cluster.local:9464
+            labels:
+              app: open-webui
+        relabel_configs:
+        - target_label: cluster
+          replacement: okd

--- a/kubernetes/prometheus/components/prometheus/config-map.yaml
+++ b/kubernetes/prometheus/components/prometheus/config-map.yaml
@@ -455,21 +455,25 @@ data:
 
         static_configs:
           - targets:
-            - xpumd.intel-device-plugins-operator.svc.cluster.local:8080
+            - xpumd.intel-device-plugins-operator.svc.cluster.local.:8080
             labels:
               app: intel-gpu
           - targets:
-            - litellm-svc.llm.svc.cluster.local:4000
+            - litellm-svc.llm.svc.cluster.local.:4000
             labels:
               app: litellm
           - targets:
-            - llama-swap-svc.llm.svc.cluster.local:8080
+            - llama-swap-svc.llm.svc.cluster.local.:8080
             labels:
               app: llama-swap
           - targets:
-            - llama-swap-svc.llm.svc.cluster.local:9100
+            - llama-swap-svc.llm.svc.cluster.local.:9100
             labels:
               app: llama-swap
+          - targets:
+            - open-webui-collector.llm.svc.cluster.local.:9464
+            labels:
+              app: open-webui
 
         metric_relabel_configs:
         - source_labels: [ __name__ ]
@@ -479,19 +483,6 @@ data:
           regex: 'process_(.+)'
           action: drop
 
-        relabel_configs:
-        - target_label: cluster
-          replacement: okd
-
-      # Open WebUI metrics via OTEL collector (OTLP → Prometheus bridge).
-      - job_name: 'open-webui'
-        scrape_interval: 30s
-        scrape_timeout: 10s
-        static_configs:
-          - targets:
-            - open-webui-collector.llm.svc.cluster.local:9464
-            labels:
-              app: open-webui
         relabel_configs:
         - target_label: cluster
           replacement: okd


### PR DESCRIPTION
## PR2/3 — OTEL Bridge for Open WebUI

Extends PR1 with the OpenTelemetry Collector bridge and Open WebUI metrics observability.

**What's included**
- OpenTelemetryCollector CR (OTLP receiver + Prometheus exporter on `:9464`)
- Open WebUI OTEL env vars: `ENABLE_OTEL`, `ENABLE_OTEL_METRICS`, `OTEL_EXPORTER_OTLP_ENDPOINT`, etc.
- Prometheus scrape jobs for `open-webui-collector` (okd + NAS)
- Grafana dashboard: request rate / p95 latency / 5xx errors
- Tool server connections (MCP Kubernetes + GitHub) — oikb added in PR3
- `kubernetes/llm/components/otel-collector/` — collector CR, network policy, kustomization component
- `kubernetes/grafana/base/dashboards/open-webui.json`

**Merge order**: Merge PR1 first, then this PR.

**Prerequisites**: Vault secrets for MCP-GitHub PAT (`homelab/llm/mcp-github/token`).
