### PR TITLE
fix(toolbox): correct k8s-gitops-ci-rc tar extraction path and add oikb KB sync daemon

### DIFF
--- a/containers/toolbox/containerfile
+++ b/containers/toolbox/containerfile
@@ -187,13 +187,12 @@ RUN K8S_GITOPS_CI_PRERELEASE=$(curl -sL ${GH_TOKEN:+-H "Authorization: token ${G
     if [ -n "${K8S_GITOPS_CI_PRERELEASE}" ] && [ "${K8S_GITOPS_CI_PRERELEASE}" != "${K8S_GITOPS_CI_VERSION}" ]; then \
       curl -fL --retry 5 --retry-delay 2 -o "k8s-gitops-ci_${K8S_GITOPS_CI_PRERELEASE}_linux_amd64.tar.gz" \
         "https://github.com/ArthurVardevanyan/k8s-gitops-ci/releases/download/v${K8S_GITOPS_CI_PRERELEASE}/k8s-gitops-ci_${K8S_GITOPS_CI_PRERELEASE}_linux_amd64.tar.gz" && \
-      tar -xzf "k8s-gitops-ci_${K8S_GITOPS_CI_PRERELEASE}_linux_amd64.tar.gz" --no-same-owner -C /tmp "k8s-gitops-ci_${K8S_GITOPS_CI_PRERELEASE}/k8s-gitops-ci" && \
-      cp /tmp/k8s-gitops-ci_${K8S_GITOPS_CI_PRERELEASE}/k8s-gitops-ci /usr/local/bin/k8s-gitops-ci-rc && \
+      tar -xzf "k8s-gitops-ci_${K8S_GITOPS_CI_PRERELEASE}_linux_amd64.tar.gz" --no-same-owner -C /tmp k8s-gitops-ci && \
+      cp /tmp/k8s-gitops-ci /usr/local/bin/k8s-gitops-ci-rc && \
       chmod +x /usr/local/bin/k8s-gitops-ci-rc && \
       rm -f "k8s-gitops-ci_${K8S_GITOPS_CI_PRERELEASE}_linux_amd64.tar.gz" && \
-      rm -rf /tmp/k8s-gitops-ci_${K8S_GITOPS_CI_PRERELEASE}; \
-    fi && \
-    rmdir /usr/local/bin/k8s-gitops-ci_${K8S_GITOPS_CI_PRERELEASE} 2>/dev/null || true
+      rm -f /tmp/k8s-gitops-ci; \
+    fi
 
 # Always ensure k8s-gitops-ci-rc exists — symlink to stable if no RC binary was installed
 RUN if [ ! -f /usr/local/bin/k8s-gitops-ci-rc ]; then \

--- a/kubernetes/llm/components/oikb/deployment.yaml
+++ b/kubernetes/llm/components/oikb/deployment.yaml
@@ -103,6 +103,8 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
+            - name: oikb-data
+              mountPath: /.oikb
       volumes:
         - name: config
           configMap:
@@ -113,3 +115,6 @@ spec:
         - name: tmp
           emptyDir:
             sizeLimit: 512Mi
+        - name: oikb-data
+          emptyDir:
+            sizeLimit: 1Gi

--- a/kubernetes/llm/components/oikb/deployment.yaml
+++ b/kubernetes/llm/components/oikb/deployment.yaml
@@ -29,6 +29,12 @@ spec:
       serviceAccountName: oikb
       enableServiceLinks: false
       dnsPolicy: ClusterFirst
+      tolerations:
+        - key: node-role.kubernetes.io/gpu
+          operator: Exists
+          effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/gpu: ""
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/kubernetes/llm/components/oikb/kustomization.yaml
+++ b/kubernetes/llm/components/oikb/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - service.yaml
   - network-policy.yaml
   - service-monitor.yaml
+  - vpa.yaml
 generatorOptions: {}
 configMapGenerator:
   - files:

--- a/kubernetes/llm/components/oikb/oikb.yaml
+++ b/kubernetes/llm/components/oikb/oikb.yaml
@@ -7,45 +7,46 @@ defaults:
 sources:
   # Web / sitemap crawler (migrated from the previous bash CronJob).
   - name: personal-site
-    source: "sitemap: https://www.arthurvardevanyan.com/sitemap.xml"
+    source: "sitemap:https://www.arthurvardevanyan.com/sitemap.xml"
     kb-id: 22c566e6-bf1b-48c1-9242-ab504260cf02
 
   # GitHub (private repo; read-only fine-grained PAT reuses mcp-github).
   - name: homelab
-    source: "github: ArthurVardevanyan/HomeLab"
+    source: "github:ArthurVardevanyan/HomeLab"
     kb-id: 5e05f04c-3adf-4003-b9d3-83b356562dce
     token: ${GITHUB_TOKEN}
 
+  # --- Disabled (enable when ready) ---
   # Nextcloud (WebDAV app password).
-  - name: documents
-    source: "nextcloud:/Documents"
-    kb-id: ${KB_DOCUMENTS_ID}
+  # - name: documents
+  #   source: "nextcloud:/Documents"
+  #   kb-id: ${KB_DOCUMENTS_ID}
 
   # Jira.
   # TODO: confirm exact env-var names (JIRA_URL / JIRA_USERNAME / JIRA_API_TOKEN?).
-  - name: jira
-    source: jira:${JIRA_PROJECT}
-    kb-id: ${KB_JIRA_ID}
-    token: ${JIRA_TOKEN}
+  # - name: jira
+  #   source: jira:${JIRA_PROJECT}
+  #   kb-id: ${KB_JIRA_ID}
+  #   token: ${JIRA_TOKEN}
 
   # Discord.
   # TODO: confirm exact env-var names and scope syntax (bot token / channel).
-  - name: discord
-    source: discord:${DISCORD_SCOPE}
-    kb-id: ${KB_DISCORD_ID}
-    token: ${DISCORD_TOKEN}
+  # - name: discord
+  #   source: discord:${DISCORD_SCOPE}
+  #   kb-id: ${KB_DISCORD_ID}
+  #   token: ${DISCORD_TOKEN}
 
   # Slack.
   # TODO: confirm exact env-var names and scope syntax (app token / channel).
-  - name: slack
-    source: slack:${SLACK_SCOPE}
-    kb-id: ${KB_SLACK_ID}
-    token: ${SLACK_TOKEN}
+  # - name: slack
+  #   source: slack:${SLACK_SCOPE}
+  #   kb-id: ${KB_SLACK_ID}
+  #   token: ${SLACK_TOKEN}
 
   # Zotero research library.
-  - name: zotero
-    source: "zotero:"
-    kb-id: ${KB_ZOTERO_ID}
+  # - name: zotero
+  #   source: "zotero:"
+  #   kb-id: ${KB_ZOTERO_ID}
 
   # Gmail — deferred. OAuth-heavy (refresh-token flow + oikb[gmail] extra),
   # not enabled until credentials are provisioned. Uncomment once ready:

--- a/kubernetes/llm/components/oikb/oikb.yaml
+++ b/kubernetes/llm/components/oikb/oikb.yaml
@@ -7,46 +7,45 @@ defaults:
 sources:
   # Web / sitemap crawler (migrated from the previous bash CronJob).
   - name: personal-site
-    source: sitemap:https://www.arthurvardevanyan.com/sitemap.xml
+    source: "sitemap: https://www.arthurvardevanyan.com/sitemap.xml"
     kb-id: 22c566e6-bf1b-48c1-9242-ab504260cf02
 
-  # GitHub (private repo; read-only fine-grained PAT).
+  # GitHub (private repo; read-only fine-grained PAT reuses mcp-github).
   - name: homelab
-    source: github:ArthurVardevanyan/HomeLab
+    source: "github: ArthurVardevanyan/HomeLab"
     kb-id: 5e05f04c-3adf-4003-b9d3-83b356562dce
     token: ${GITHUB_TOKEN}
 
-  # --- Disabled (enable when ready) ---
   # Nextcloud (WebDAV app password).
-  # - name: documents
-  #   source: "nextcloud:/Documents"
-  #   kb-id: ${KB_DOCUMENTS_ID}
+  - name: documents
+    source: "nextcloud:/Documents"
+    kb-id: ${KB_DOCUMENTS_ID}
 
   # Jira.
   # TODO: confirm exact env-var names (JIRA_URL / JIRA_USERNAME / JIRA_API_TOKEN?).
-  # - name: jira
-  #   source: jira:${JIRA_PROJECT}
-  #   kb-id: ${KB_JIRA_ID}
-  #   token: ${JIRA_TOKEN}
+  - name: jira
+    source: jira:${JIRA_PROJECT}
+    kb-id: ${KB_JIRA_ID}
+    token: ${JIRA_TOKEN}
 
   # Discord.
   # TODO: confirm exact env-var names and scope syntax (bot token / channel).
-  # - name: discord
-  #   source: discord:${DISCORD_SCOPE}
-  #   kb-id: ${KB_DISCORD_ID}
-  #   token: ${DISCORD_TOKEN}
+  - name: discord
+    source: discord:${DISCORD_SCOPE}
+    kb-id: ${KB_DISCORD_ID}
+    token: ${DISCORD_TOKEN}
 
   # Slack.
   # TODO: confirm exact env-var names and scope syntax (app token / channel).
-  # - name: slack
-  #   source: slack:${SLACK_SCOPE}
-  #   kb-id: ${KB_SLACK_ID}
-  #   token: ${SLACK_TOKEN}
+  - name: slack
+    source: slack:${SLACK_SCOPE}
+    kb-id: ${KB_SLACK_ID}
+    token: ${SLACK_TOKEN}
 
   # Zotero research library.
-  # - name: zotero
-  #   source: "zotero:"
-  #   kb-id: ${KB_ZOTERO_ID}
+  - name: zotero
+    source: "zotero:"
+    kb-id: ${KB_ZOTERO_ID}
 
   # Gmail — deferred. OAuth-heavy (refresh-token flow + oikb[gmail] extra),
   # not enabled until credentials are provisioned. Uncomment once ready:

--- a/kubernetes/llm/components/oikb/vpa.yaml
+++ b/kubernetes/llm/components/oikb/vpa.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: oikb
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: oikb
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: oikb
+  updatePolicy:
+    updateMode: "InPlaceOrRecreate"
+  resourcePolicy:
+    containerPolicies:
+      - containerName: oikb
+        minAllowed:
+          cpu: 50m
+          memory: 128Mi
+        maxAllowed:
+          cpu: "1"
+          memory: 1Gi
+        controlledResources:
+          - cpu
+          - memory
+        controlledValues: RequestsOnly


### PR DESCRIPTION
## Toolbox Fix

- Correct k8s-gitops-ci-rc tar extraction path

## oikb — Open WebUI Knowledge Base Sync Daemon

- Add `oikb` daemon: incremental multi-source sync into Open WebUI Knowledge Bases
- Active sources: personal-site (sitemap), homelab (GitHub)
- nextcloud, jira, discord, slack, zotero sources commented out (enable when credentials are provisioned)
- Added ServiceMonitor for Prometheus metrics scraping
- Added VPA for auto-scaling (50m-1 CPU, 128Mi-1Gi memory)
- Added network policy: ingress from Prometheus + Open WebUI, egress to DNS (53), Open WebUI (8080), and internet (80/443)
- Hardcoded `GITHUB_ORG` (`ArthurVardevanyan`) and `KB_*_ID` values in configMap
- ESO ExternalSecret manages `OPEN_WEBUI_API_KEY`, `OIKB_API_KEY`, and `GITHUB_TOKEN`
- Added oikb to Prometheus LLM job static_configs
- EmptyDir volume (`/.oikb`, 1Gi) for sync history database
- GPU nodeSelector and toleration (consistent with other LLM stack components)
- readOnlyRootFilesystem with seccomp profile, dropped ALL capabilities