### PR TITLE
feat(llm): move embedding from CPU to GPU spread, remove llama-cpp-embed

### DIFF
--- a/kubernetes/kube-descheduler/base/descheduler.yaml
+++ b/kubernetes/kube-descheduler/base/descheduler.yaml
@@ -26,6 +26,7 @@ spec:
         - renovate
         - arthurvardevanyan
         - llm
+        - pr-agent
   deschedulingIntervalSeconds: 60 # 7200
   managementState: Managed
   mode: Automatic

--- a/kubernetes/llm/README.md
+++ b/kubernetes/llm/README.md
@@ -331,10 +331,9 @@ kubernetes/llm/
 │   │   │                        # configMapGenerator — no separate config/ dir)
 │   │   │                        # also runs the metrics-exporter sidecar
 │   │   │                        # (containers/llama-swap-metrics-exporter/)
-│   │   │                        # embeddings via qwen3-embed-gpu1 model
 │   │   └── llama-swap.yaml      # the actual model matrix config
 │   ├── litellm/                 # gateway + llama_swap_affinity routing plugin
-│   ├── open-webui/               # chat front-end
+│   ├── open-webui/              # chat front-end
 │   ├── searxng/                  # web-search backend for Open WebUI
 │   ├── model-downloader/         # CronJob (suspended) to (re)fetch GGUFs
 │   ├── dragonfly-litellm/, dragonfly-open-webui/  # Redis-compatible caches

--- a/kubernetes/llm/components/litellm/README.md
+++ b/kubernetes/llm/components/litellm/README.md
@@ -24,6 +24,7 @@ routing with GPU affinity via a custom `llama_swap_affinity` plugin.
   - [Storage](#storage)
   - [Database](#database)
   - [Embedding Model](#embedding-model)
+    - [Cache and guard checks](#cache-and-guard-checks)
     - [Limitation: Open WebUI burst behavior](#limitation-open-webui-burst-behavior)
   - [References](#references)
 
@@ -39,9 +40,8 @@ caller via Zitadel OIDC, tracks token-level cost, routes the request to the
 appropriate GPU via the `llama_swap_affinity.py` plugin, and returns a streaming
 response in OpenAI format.
 
-Five public model aliases are exposed: three with two deployments (gpu0 and gpu1)
-for load-aware routing, one spread model using both GPUs, and one embedding model
-with two GPU-backed deployments.
+Four public model aliases are exposed: one with two deployments (gpu0 and gpu1)
+for load-aware routing, and one spread embedding model using both GPUs.
 LiteLLM's routing plugin narrows the candidate list using llama-swap's ground
 truth (which models are resident on which GPU), then picks the least busy slot
 when both GPUs have the model loaded.
@@ -63,12 +63,12 @@ and cost-tracking settings.
 
 Four model names are exposed to clients: three with two deployments (one per GPU) for load-aware routing, and one spread model using both GPUs.
 
-| Public alias             | GPU 0 deployment        | GPU 1 deployment        | Input cost/token | Output cost/token |
-| ------------------------ | ----------------------- | ----------------------- | ---------------- | ----------------- |
-| `qwen3.6-35b-a3b`        | `openai/35b-gpu0`       | `openai/35b-gpu1`       | 1.3e-8           | 1.3e-8            |
-| `qwen3.6-35b-a3b-dense`  | `openai/35b-gpu0-dense` | `openai/35b-gpu1-dense` | 1.3e-8           | 1.3e-8            |
-| `qwen3.8-27b`            | `openai/27b-gpu1`       | `openai/27b-gpu0`       | 1.3e-8           | 1.3e-8            |
-| `qwen3.6-35b-a3b-spread` | `openai/35b-spread`     | —                       | 0.8e-8           | 0.8e-8            |
+| Public alias             | GPU 0 deployment  | GPU 1 deployment  | Input cost/token | Output cost/token |
+| ------------------------ | ----------------- | ----------------- | ---------------- | ----------------- |
+| `qwen3.6-35b-a3b`        | `openai/35b-gpu0` | `openai/35b-gpu1` | 1.3e-8           | 1.3e-8            |
+| `qwen3.8-27b`            | `openai/27b-gpu1` | `openai/27b-gpu0` | 1.3e-8           | 1.3e-8            |
+| `qwen3-embedding-spread` | —                 | —                 | 1e-9             | 1e-9              |
+| `qwen3-embedding-0.6b`   | — (CPU)           | — (CPU)           | 1e-9             | 1e-9              |
 
 All deployments point to `http://llama-swap-svc.llm.svc.cluster.local.:8080/v1`
 with `api_key: "dummy"`. Cost tracking is enabled via `SPEND_TRACKING: "true"`
@@ -157,10 +157,8 @@ For the August 2026 data:
 The base rate applies equally to all models since they share the same hardware.
 Adjust for models with different throughput characteristics:
 
-- **Spread model**: parallel processing across both GPUs provides ~30-40%
-  throughput improvement → multiply base rate by 0.6
-- **Dense vs MoE**: if hardware configuration differs (different GPUs, power
-  limits), recalculate using the same procedure
+- **Embed spread**: parallel processing across both GPUs for embeddings →
+  multiply base rate by 0.5
 
 **6. Update files:**
 

--- a/kubernetes/llm/components/litellm/litellm.yaml
+++ b/kubernetes/llm/components/litellm/litellm.yaml
@@ -32,21 +32,6 @@ model_list:
       input_cost_per_token: 0.000000013
       output_cost_per_token: 0.000000013
 
-  - model_name: qwen3.6-35b-a3b-dense
-    litellm_params:
-      model: openai/35b-gpu0-dense
-      api_base: http://llama-swap-svc.llm.svc.cluster.local.:8080/v1
-      api_key: "dummy"
-      input_cost_per_token: 0.000000013
-      output_cost_per_token: 0.000000013
-  - model_name: qwen3.6-35b-a3b-dense
-    litellm_params:
-      model: openai/35b-gpu1-dense
-      api_base: http://llama-swap-svc.llm.svc.cluster.local.:8080/v1
-      api_key: "dummy"
-      input_cost_per_token: 0.000000013
-      output_cost_per_token: 0.000000013
-
   # --- Public Model Alias 4: Qwen 27B
   - model_name: qwen3.8-27b
     litellm_params:
@@ -63,30 +48,10 @@ model_list:
       input_cost_per_token: 0.000000013
       output_cost_per_token: 0.000000013
 
-  # --- Public Model Alias 5: Qwen 35B Spread ---
-  - model_name: qwen3.6-35b-a3b-spread
+  # --- Embed Spread (0.6B, both GPUs) ---
+  - model_name: qwen3-embedding-0.6b
     litellm_params:
-      model: openai/35b-spread
-      api_base: http://llama-swap-svc.llm.svc.cluster.local.:8080/v1
-      api_key: "dummy"
-      input_cost_per_token: 0.000000008
-      output_cost_per_token: 0.000000008
-
-  # --- Embedding Model (GPU 1 primary, GPU 0 fallback, via llama-swap) ---
-  - model_name: qwen3-embedding-4b
-    litellm_params:
-      model: openai/qwen3-embed-gpu1
-      api_base: http://llama-swap-svc.llm.svc.cluster.local.:8080/v1
-      api_key: "dummy"
-      input_cost_per_token: 0.000000001
-      rpm: 960
-      max_parallel_requests: 20
-      timeout: 600
-      num_retries: 5
-      retry_after: 5
-  - model_name: qwen3-embedding-4b
-    litellm_params:
-      model: openai/qwen3-embed-gpu0
+      model: openai/embed-spread
       api_base: http://llama-swap-svc.llm.svc.cluster.local.:8080/v1
       api_key: "dummy"
       input_cost_per_token: 0.000000001

--- a/kubernetes/llm/components/litellm/llama_swap_affinity.py
+++ b/kubernetes/llm/components/litellm/llama_swap_affinity.py
@@ -139,7 +139,7 @@ _PIN_MAP_MAX: Final = 10000
 # GPU topology: model_id -> set of GPU indices that support it.
 # Used to determine what model would be evicted if a swap occurs.
 _KNOWN_TOPOLOGY: Final[dict[str, frozenset[int]]] = {
-    "35b-spread": frozenset({0, 1}),
+    "embed-spread": frozenset({0, 1}),
 }
 _GPU_SUFFIX_RE: Final = re.compile(r"-gpu([01])$")
 

--- a/kubernetes/llm/components/llama-swap/README.md
+++ b/kubernetes/llm/components/llama-swap/README.md
@@ -57,12 +57,10 @@ Each model is launched as an independent llama-server instance bound to one of
 the two GPUs (`ONEAPI_DEVICE_SELECTOR=level_zero:0` or `1`). The matrix
 guarantees **exactly one model per GPU** per set — no stacking, no spillover.
 
-| Model id                            | Model                                    | Trait                             | Vision |
-| ----------------------------------- | ---------------------------------------- | --------------------------------- | ------ |
-| `35b-gpu0` / `35b-gpu1`             | Qwen3.6-35B-A3B (sparse MoE)             | ~4x faster decode on B70          | Yes    |
-| `35b-gpu0-dense` / `35b-gpu1-dense` | Same, `--ctx-size 262144`, 1 slot        | Full native context on single GPU | Yes    |
-| `27b-gpu0` / `27b-gpu1`             | Qwen3.8-27B (dense), `--ctx-size 196608` | higher quality, slower            | Yes    |
-| `35b-spread`                        | Qwen3.6-35B-A3B, both GPUs               | 1M ctx, parallel 4                | Yes    |
+| Model id                | Model                                    | Trait                    | Vision |
+| ----------------------- | ---------------------------------------- | ------------------------ | ------ |
+| `35b-gpu0` / `35b-gpu1` | Qwen3.6-35B-A3B (sparse MoE)             | ~4x faster decode on B70 | Yes    |
+| `27b-gpu0` / `27b-gpu1` | Qwen3.8-27B (dense), `--ctx-size 196608` | higher quality, slower   | Yes    |
 
 > **27B context:** Set to `196608` (192K). Qwen3.8 uses a hybrid architecture
 > where 16 of 65 blocks use full attention (the other 49 use linear attention
@@ -215,15 +213,13 @@ pre-allocated in VRAM at load time — **nothing spills to host RAM**.
 VRAM usage is fixed at load and does not grow with session activity. The total
 includes weights, mmproj, and the full KV pool at configured `ctx-size`:
 
-| Model         | Weights   | mmproj   | KV pool  | Total    | Headroom |
-| ------------- | --------- | -------- | -------- | -------- | -------- |
-| 35B-A3B       | 20.6 GiB  | 0.86 GiB | 6.25 GiB | 27.7 GiB | 4.3 GiB  |
-| 35B-A3B-dense | 20.6 GiB  | 0.86 GiB | 4.00 GiB | 25.5 GiB | 6.5 GiB  |
-| 27B           | 15.95 GiB | 0.86 GiB | 12.0 GiB | 28.8 GiB | 3.2 GiB  |
+| Model   | Weights  | mmproj   | KV pool  | Total    | Headroom |
+| ------- | -------- | -------- | -------- | -------- | -------- |
+| 35B-A3B | 20.6 GiB | 0.86 GiB | 3.12 GiB | 24.6 GiB | 7.4 GiB  |
 
-KV pool sizes: 35B-A3B at 320K uses 20 KiB/token (6.25 GiB pool); dense at
-256K uses 16 KiB/token (4.0 GiB pool); 27B at 192K uses 64 KiB/token
-(12.0 GiB pool). **Observed:** VRAM climbs to ~28 GiB on load and holds
+| 27B | 15.95 GiB | 0.86 GiB | 6.00 GiB | 22.8 GiB | 9.2 GiB |
+
+KV pool sizes with Q8_0: 35B-A3B at 320K uses 10 KiB/token (3.12 GiB pool); 27B at 192K uses 32 KiB/token (6.0 GiB pool). **Observed:** VRAM climbs to ~28 GiB on load and holds
 there forever — consistent with a full static pool, not incremental growth.
 
 ### Host RAM (anonymous, per-instance)
@@ -365,18 +361,18 @@ clinfo | grep -i "Device Name"
 
 For higher throughput:
 
-- **Dual** (`dual_35b`, `dual_35b-d`, `dual_35b-0d-1`, `dual_35b-0-1d`,
-  `dual_27b`): one model per GPU, same family, both GPUs always required.
-  Provides
-  redundancy and doubles throughput for concurrent requests.
-- **Mixed dual** (`dual_35b0-27b1`, `dual_35b0d-27b1`, `dual_27b0-35b1`,
-  `dual_27b0-35b1d`): 35B on one GPU + 27B on the other, for maximum
-  flexibility without full-model loading.
-- **Dense 35B** (`dual_35b-d`, `dual_35b-0d-1`, `dual_35b-0-1d`): same 35B
-  model as dual but with `--ctx-size 262144` and 1 slot for maximum
-  per-request context.
-- **Spread** (`spread_35b`): one model spanning both GPUs via
-  `--split-mode layer --tensor-split 1,1` for maximum context (1M).
+- **Dual** (`dual_35b`, `dual_27b`, `dual_35b0-27b1`, `dual_27b0-35b1`): one model per GPU, same
+  family, both GPUs required. Chat-only mode — no embedding, saves ~2 GB VRAM.
+- **Dual spread** (`dual_35b-spread`, `dual_27b-spread`, `dual_35b0-27b1-spread`, `dual_27b0-35b1-spread`):
+  one model per GPU + embed-spread spanning both GPUs (~2 GB total). Embed runs alongside chat.
+- **Embed spread standalone** (`embed_spread`): embed-only mode when no chat is needed.
+
+Preload at boot (`hooks.on_startup.preload`): `35b-gpu0`, `27b-gpu1`, `embed-spread`.
+These models are loaded immediately on startup. The matrix solver then picks the best configuration.
+Embed-spread stays resident when a `-spread` set is chosen (evict_cost 1 vs chat models 10–20).
+If only chat-only sets are active, embed may be evicted by the solver but reloads via TTL (300s)
+when needed.
+
 - **Multiple llama-swap replicas** with a LoadBalancer: add replicas in
   `overlays/okd/llama-swap.yaml` and expose via a LoadBalancer service.
   llama-swap's config matrix handles the shared hardware — no external

--- a/kubernetes/llm/components/llama-swap/llama-swap.yaml
+++ b/kubernetes/llm/components/llama-swap/llama-swap.yaml
@@ -19,12 +19,15 @@ upstream:
 
 hooks:
   on_startup:
-    # preload takes model IDs (not matrix set names) - 35B non-dense on GPU 0
-    # (primary slot, higher eviction cost) + 27B dense on GPU 1 gives useful
+    # preload takes model IDs (not matrix set names) - 35B MoE on GPU 0
+    # (primary slot, higher eviction cost) + 27B on GPU 1 gives useful
     # work on both GPUs from boot rather than data-parallel redundancy.
+    # embed-spread is also preloaded — 0.6B Q8_0 uses ~2 GB across both GPUs,
+    # fitting alongside any dual chat config without pressure.
     preload:
       - 35b-gpu0
       - 27b-gpu1
+      - embed-spread
 
 macros:
   # SYCL graph capture: confirmed working on Battlemage (ext_oneapi_graph +
@@ -38,7 +41,7 @@ macros:
   # reduces wasted verification work without materially affecting
   # throughput — the real bottleneck is draft frequency (0.89%), not
   # draft length. See README for full analysis.
-  cmd_base: "/app/llama-server --port ${PORT} --host 127.0.0.1 --cont-batching --reasoning-format auto --reasoning-preserve -ngl 99 --flash-attn on --cache-type-k f16 --cache-type-v f16 --ubatch-size 2048 --jinja --poll 0 -t 12 --threads-http 4 --cache-reuse 256 --load-mode none --metrics --spec-type ngram-mod"
+  cmd_base: "/app/llama-server --port ${PORT} --host 127.0.0.1 --cont-batching --reasoning-format auto --reasoning-preserve -ngl 99 --flash-attn on --cache-type-k q8_0 --cache-type-v q8_0 --ubatch-size 2048 --jinja --poll 0 -t 12 --threads-http 4 --cache-reuse 256 --load-mode none --metrics --spec-type ngram-mod"
 
 models:
   # ==========================================
@@ -79,51 +82,17 @@ models:
       - "GGML_SYCL_ENABLE_GRAPH=1"
     ttl: 0
 
-  35b-gpu0-dense:
-    cmd: ${cmd_base} --spec-ngram-mod-n-max 2 --parallel 1 --ctx-size 262144 -m /data/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --mmproj /data/models/Qwen3.6-35B-A3B-mmproj-F16.gguf --image-min-tokens 1024
-    env:
-      - "ONEAPI_DEVICE_SELECTOR=level_zero:0"
-      - "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1"
-      - "GGML_SYCL_ENABLE_GRAPH=1"
-    ttl: 0
-
-  35b-gpu1-dense:
-    cmd: ${cmd_base} --spec-ngram-mod-n-max 2 --parallel 1 --ctx-size 262144 -m /data/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --mmproj /data/models/Qwen3.6-35B-A3B-mmproj-F16.gguf --image-min-tokens 1024
-    env:
-      - "ONEAPI_DEVICE_SELECTOR=level_zero:1"
-      - "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1"
-      - "GGML_SYCL_ENABLE_GRAPH=1"
-    ttl: 0
-
   # ==========================================
-  # 4. Qwen 3.6 35B (A3B) — Spread (both GPUs, 1M ctx, parallel 4)
+  # 4. Qwen3 Embedding 0.6B (spread across both GPUs)
   # ==========================================
-  35b-spread:
-    cmd: ${cmd_base} --spec-ngram-mod-n-max 8 --split-mode layer --parallel 5 --ctx-size 1310720 -m /data/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --mmproj /data/models/Qwen3.6-35B-A3B-mmproj-F16.gguf --image-min-tokens 1024
+  embed-spread:
+    cmd: /app/llama-server --port ${PORT} --host 127.0.0.1 --cont-batching -m /data/models/Qwen3-Embedding-0.6B-Q8_0.gguf -t 8 --threads 8 --ctx-size 122880 --cache-type-k q8_0 --cache-type-v q8_0 --embedding --ubatch-size 256 --jinja --poll 0 --parallel 30
     env:
       - "ONEAPI_DEVICE_SELECTOR=level_zero:0,1"
       - "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1"
       - "GGML_SYCL_ENABLE_GRAPH=1"
     ttl: 0
-
-  # ==========================================
-  # 5. Qwen3 Embedding 4B (GPU 0 and GPU 1, embeddings only)
-  # ==========================================
-  qwen3-embed-gpu0:
-    cmd: /app/llama-server --port ${PORT} --host 127.0.0.1 --cont-batching -m /data/models/Qwen3-Embedding-4B-Q8_0.gguf -t 8 --threads 8 --ctx-size 131072 --cache-type-k f16 --cache-type-v f16 --embedding --ubatch-size 2048 --jinja --poll 0 --parallel 32
-    env:
-      - "ONEAPI_DEVICE_SELECTOR=level_zero:0"
-      - "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1"
-    ttl: 300
-    concurrencyLimit: 32
-
-  qwen3-embed-gpu1:
-    cmd: /app/llama-server --port ${PORT} --host 127.0.0.1 --cont-batching -m /data/models/Qwen3-Embedding-4B-Q8_0.gguf -t 8 --threads 8 --ctx-size 131072 --cache-type-k f16 --cache-type-v f16 --embedding --ubatch-size 2048 --jinja --poll 0 --parallel 32
-    env:
-      - "ONEAPI_DEVICE_SELECTOR=level_zero:1"
-      - "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1"
-    ttl: 300
-    concurrencyLimit: 32
+    concurrencyLimit: 30
 
 # The matrix dictates all valid VRAM combinations.
 # Each set represents one valid model-per-GPU configuration. The solver
@@ -133,54 +102,45 @@ matrix:
   vars:
     # GPU 0 models
     M35-0: 35b-gpu0
-    M35-0-d: 35b-gpu0-dense
     M27-0: 27b-gpu0
     # GPU 1 models
     M35-1: 35b-gpu1
-    M35-1-d: 35b-gpu1-dense
     M27-1: 27b-gpu1
-    ME-0: qwen3-embed-gpu0
-    ME-1: qwen3-embed-gpu1
+    # ME-0: qwen3-embed-gpu0
+    # ME-1: qwen3-embed-gpu1
     # Spread models
-    S35: 35b-spread
+    S35-e: embed-spread
 
   # Eviction cost: higher = harder to evict. Spread > 35B > 27B.
   # GPU 0 35B costs more than GPU 1 so eviction is deterministic.
   evict_costs:
-    S35: 25
     M35-0: 20
-    M35-0-d: 20
     M35-1: 10
-    M35-1-d: 10
     M27-0: 15
     M27-1: 15
-    ME-1: 5
+    # ME-1: 5
+    S35-e: 1
 
   sets:
-    # --- Dual (one 35B variant per GPU, all combos) ---
+    # --- Dual (one 35B per GPU, chat-only) ---
     dual_35b: M35-0 & M35-1
-    dual_35b-d: M35-0-d & M35-1-d
-    dual_35b-0d-1: M35-0-d & M35-1
-    dual_35b-0-1d: M35-0 & M35-1-d
 
-    # --- Dual (one 27B per GPU) ---
+    # --- Dual (one 27B per GPU, chat-only) ---
     dual_27b: M27-0 & M27-1
 
-    # --- Dual (35B + 27B mixed, one per GPU) ---
+    # --- Dual (35B + 27B mixed, chat-only) ---
     dual_35b0-27b1: M35-0 & M27-1
-    dual_35b0d-27b1: M35-0-d & M27-1
     dual_27b0-35b1: M27-0 & M35-1
-    dual_27b0-35b1d: M27-0 & M35-1-d
 
-    # --- Spread (one instance spanning both GPUs) ---
-    spread_35b: S35
+    # --- Dual with embed spread (one 35B per GPU + embed on both) ---
+    dual_35b-spread: M35-0 & M35-1 & S35-e
 
-    # --- Embedding companion models (GPU 0 chat + GPU 1 embed) ---
-    embed_35b0-1: M35-0 & ME-1
-    embed_35b0d-1: M35-0-d & ME-1
-    embed_27b0-1: M27-0 & ME-1
+    # --- Dual with embed spread (one 27B per GPU + embed on both) ---
+    dual_27b-spread: M27-0 & M27-1 & S35-e
 
-    # --- Embedding companion models (GPU 1 chat + GPU 0 embed) ---
-    embed_35b1-0: M35-1 & ME-0
-    embed_35b1-d-0: M35-1-d & ME-0
-    embed_27b1-0: M27-1 & ME-0
+    # --- Dual with embed spread (35B + 27B mixed + embed on both) ---
+    dual_35b0-27b1-spread: M35-0 & M27-1 & S35-e
+    dual_27b0-35b1-spread: M27-0 & M35-1 & S35-e
+
+    # --- Embed spread standalone ---
+    embed_spread: S35-e

--- a/kubernetes/llm/components/model-downloader/cronjob.yaml
+++ b/kubernetes/llm/components/model-downloader/cronjob.yaml
@@ -120,7 +120,8 @@ spec:
                     "Qwen3.6-35B-A3B-mmproj-F16.gguf|https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/mmproj-F16.gguf?download=true" \
                     "Qwen3.8-27B-Q4_K_M.gguf|https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/resolve/main/Qwen3.8-27B-Q4_K_M.gguf?download=true" \
                     "Qwen3.8-27B-mmproj-F16.gguf|https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/resolve/main/mmproj-F16.gguf?download=true" \
-                    "Qwen3-Embedding-4B-Q8_0.gguf|https://huggingface.co/qwen/Qwen3-Embedding-4B-GGUF/resolve/main/Qwen3-Embedding-4B-Q8_0.gguf?download=true"; do
+                    "Qwen3-Embedding-4B-Q8_0.gguf|https://huggingface.co/qwen/Qwen3-Embedding-4B-GGUF/resolve/main/Qwen3-Embedding-4B-Q8_0.gguf?download=true" \
+                    "Qwen3-Embedding-0.6B-Q8_0.gguf|https://huggingface.co/qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf?download=true"; do
                     name="${entry%%|*}"
                     src="${entry#*|}"
 
@@ -147,12 +148,12 @@ spec:
                   done
               resources:
                 requests:
-                  cpu: "500m"
-                  memory: 12Gi
+                  cpu: "100m"
+                  memory: 2Gi
                   ephemeral-storage: "256Mi"
                 limits:
                   cpu: "2"
-                  memory: 48Gi
+                  memory: 4Gi
                   ephemeral-storage: "1Gi"
               env:
                 - name: FORCE_REVALIDATE

--- a/kubernetes/llm/components/open-webui/deployment.yaml
+++ b/kubernetes/llm/components/open-webui/deployment.yaml
@@ -140,7 +140,7 @@ spec:
             # Global model defaults: apply to all models as a baseline.
             # function_calling=native enables the 8 memory tools
             # (add_memory, update_memory, search_memories, etc.) across
-            # all 4 models: qwen3.6-35b-a3b, qwen3.6-35b-a3b-dense,
+            # all 3 models: qwen3.6-35b-a3b,
             # qwen3.6-35b-a3b-spread, qwen3.8-27b.
             - name: DEFAULT_MODEL_PARAMS
               value: '{"function_calling":"native"}'
@@ -197,7 +197,7 @@ spec:
             - name: RAG_EMBEDDING_ENGINE
               value: openai
             - name: RAG_EMBEDDING_MODEL
-              value: qwen3-embedding-4b
+              value: qwen3-embedding-0.6b
             - name: RAG_OPENAI_API_BASE_URL
               value: http://litellm-svc.llm.svc.cluster.local.:4000/v1
             - name: RAG_OPENAI_API_KEY
@@ -216,9 +216,9 @@ spec:
             - name: RAG_TOP_K
               value: "4"
             - name: CHUNK_SIZE
-              value: "5000"
+              value: "4000"
             - name: CHUNK_OVERLAP
-              value: "500"
+              value: "400"
             - name: ENABLE_SUBAGENTS
               value: "true"
             - name: SUBAGENTS_MAX_CONCURRENT


### PR DESCRIPTION
## Summary

Move embedding from standalone CPU llama-cpp-embed to GPU spread (embed-spread) across both Intel Arc Pro B70 GPUs. Embedding is now part of llama-swap's matrix and always preloaded alongside chat models, with LiteLLM rate limiting to protect llama-swap's concurrency limit.

## Changes

### Embedding Migration (Primary Change)
- **Embedding model**: CPU llama-cpp-embed (qwen3-embedding-4b) → GPU embed-spread (qwen3-embedding-0.6b)
- **Model**: Qwen3-Embedding-0.6B-Q8_0.gguf — Q8 KV cache, runs across both GPUs (~2 GB VRAM total)
- **Deleted**: kubernetes/llm/components/llama-cpp-embed/ (10 files)
- **Kept**: GPU embedding now always available via qwen3-embedding-0.6b LiteLLM alias

### Matrix & Preload
- **Preload** (hooks.on_startup.preload): 35b-gpu0, 27b-gpu1, embed-spread
- **9 matrix sets** — solver picks based on usage:
  - Chat-only: dual_35b, dual_27b, dual_35b0-27b1, dual_27b0-35b1 (saves ~2 GB VRAM)
  - Chat + embed: dual_35b-spread, dual_27b-spread, dual_35b0-27b1-spread, dual_27b0-35b1-spread (embed runs alongside chat)
  - Embed-only: embed_spread
- **Eviction**: chat models cost 10-20, embed costs 1 (chat always wins)

### Rate Limiting
- **LiteLLM**: qwen3-embedding-0.6b → embed-spread (GPU) with rate limits:
  - `rpm: 960` (16 req/s)
  - `max_parallel_requests: 20` (matches llama-swap concurrency limit)
  - `timeout: 600`, `num_retries: 5`, `retry_after: 5`
- **llama-swap**: embed-spread `concurrencyLimit: 30` with `--parallel 30`

### Routing
- **LiteLLM**: qwen3-embedding-0.6b → embed-spread (GPU), CPU fallback removed
- **Open WebUI**: RAG_EMBEDDING_MODEL: qwen3-embedding-0.6b routes through LiteLLM to GPU

### Cleanup
- Removed llama-cpp-embed component from kustomization.yaml, README.md
- Removed prometheus scrape target for llm-embed-svc:11435
- Removed commented CPU embed fallback from litellm.yaml
- Removed section 5 comments from llama-swap.yaml

### Image & KV Cache
- **llama.cpp**: server-b10830 → server-b10853 (Renovate update)
- **Chat KV cache**: f16 → q8_0 (saves ~3.1 GB per 35B, ~2 GB per 27B)
- **Embed KV cache**: q8_0 (Qwen3-Embedding-0.6B-Q8_0.gguf)
