### PR TITLE
feat(buildah): fuse

### DIFF
--- a/tekton/tasks/buildah/0.7.1/buildah.yaml
+++ b/tekton/tasks/buildah/0.7.1/buildah.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    io.kubernetes.cri-o.Devices: /dev/fuse
     tekton.dev/categories: Image Build
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/tags: image-build
@@ -32,8 +33,8 @@ spec:
       description: The location of the buildah builder image.
       default: quay.io/buildah/stable:v1.43.1-immutable@sha256:fc649e1899c4e09a8e19d6fbdbda178d2008fa4186d5a280211f8ffa59e77e32
     - name: STORAGE_DRIVER
-      description: Set buildah storage driver
-      default: vfs # overlay
+      description: Buildah storage driver (fuse-overlayfs uses /dev/fuse via CRI-O annotation; use vfs as a fallback)
+      default: fuse-overlayfs
     - name: DOCKERFILE
       description: Path to the Dockerfile to build.
       default: ./Dockerfile


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **PR Type**
Enhancement


___

### **Description**
- Enable `fuse-overlayfs` storage driver for builds

- Add CRI-O `/dev/fuse` device annotation

- Update default storage driver to `fuse-overlayfs`

- Clarify storage driver fallback documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  TaskConfig["Task Config"] -- "updates" --> StorageDriver["Storage Driver"]
  StorageDriver -- "defaults to" --> FuseOverlayFS["fuse-overlayfs"]
  FuseOverlayFS -- "requires" --> CRIAnnotation["CRI-O Annotation"]
  CRIAnnotation -- "mounts" --> DevFuse["/dev/fuse"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>buildah.yaml</strong><dd><code>Enable `fuse-overlayfs` storage driver</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tekton/tasks/buildah/0.7.1/buildah.yaml

<ul><li>Added CRI-O <code>/dev/fuse</code> device annotation<br> <li> Changed default storage driver to <code>fuse-overlayfs</code><br> <li> Updated parameter description with fallback info</ul>


</details>


  </td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/718/files#diff-a06e0acb45a9d255106909dabaaa217a9f909d89c1cb45051302424ef2e4ee08">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>⚙️ Agent run details</strong></summary>

- Model: openai/qwen3.6-35b-a3b
- Tokens: 4,335 in / 4,225 out / 8,560 total
- Time cost: 56.4s
- AI calls: 1

</details>
