### PR TITLE
feat: bump CPU and startup probe for external gateway

### DIFF
--- a/okd/gateway/components/gateway/external/configmap.yaml
+++ b/okd/gateway/components/gateway/external/configmap.yaml
@@ -129,10 +129,17 @@ data:
                       - /bin/sh
                       - -c
                       - sleep 45
+              startupProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                httpGet:
+                  path: /healthz/ready
+                  port: 15021
               resources:
                 requests:
-                  cpu: 75m
+                  cpu: 100m
                   memory: 1Gi
                 limits:
-                  cpu: 300m
+                  cpu: 450m
                   memory: 2Gi


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Changes

- CPU requests: 75m -> 100m
- CPU limits: 300m -> 450m (enables ~4 GOMAXPROCS for parallel WASM init instead of single-threaded)
- Startup probe period: 1s -> 5s
- Startup probe initialDelay: 0s -> 10s
- Total startup timeout: ~30s -> ~160s

## Rationale

External gateway pods were stuck in startup probe failures (port 15021 connection refused) because with cpu: 300m GOMAXPROCS is capped to 1, serializing WASM plugin download, ruleset parsing, and WAF initialization.

The internal gateway (which boots reliably) uses cpu: 450m -> ~4 parallel goroutines. This aligns the external gateway with the same configuration.

The startup probe extension provides a safety net for cold starts where Coraza ruleset fetch takes longer than 30s.

## VPA

No changes needed -- VPA only controls memory requests, not CPU or probes.

## Files Changed

- okd/gateway/components/gateway/external/configmap.yaml (+9/-2)


___

### **PR Type**
Enhancement


___

### **Description**
- Increase CPU requests and limits for WASM initialization

- Extend startup probe timeout to prevent cold-start failures

- Align external gateway configuration with internal gateway standards


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ConfigMap["configmap.yaml"] --> Resources["resources"]
  ConfigMap --> Probes["startupProbe"]
  Resources -- "cpu: 75m→100m" --> Requests["requests"]
  Resources -- "cpu: 300m→450m" --> Limits["limits"]
  Probes -- "period: 5s, delay: 10s" --> ProbeConfig["probe config"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configmap.yaml</strong><dd><code>Update CPU resources and startup probe configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

okd/gateway/components/gateway/external/configmap.yaml

<ul><li>Added <code>startupProbe</code> with extended timeout<br> <li> Increased CPU requests from <code>75m</code> to <code>100m</code><br> <li> Increased CPU limits from <code>300m</code> to <code>450m</code></ul>


</details>


  </td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/720/files#diff-e72cdb25a70a6fcff45d2fdecaaec96d160ecb3da7526c602825723ed70b01cb">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>⚙️ Agent run details</strong></summary>

- Model: openai/qwen3.6-35b-a3b
- Tokens: 4,431 in / 4,256 out / 8,687 total
- Time cost: 124.2s
- AI calls: 1

</details>
