### PR TITLE
feat(llm): migrate open-webui orphan cleanup to Go CronJob

### DIFF
--- a/kubernetes/llm/components/cnpg-open-webui/network-policy.yaml
+++ b/kubernetes/llm/components/cnpg-open-webui/network-policy.yaml
@@ -215,6 +215,16 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: llm
+          podSelector:
+            matchLabels:
+              app: open-webui-cleanup
+      ports:
+        - protocol: TCP
+          port: 5432
+    - from:
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: cnpg-system
           podSelector:
             matchLabels:

--- a/kubernetes/llm/components/open-webui-cleanup/cleanup-openwebui-orphans.go
+++ b/kubernetes/llm/components/open-webui-cleanup/cleanup-openwebui-orphans.go
@@ -143,51 +143,55 @@ func deleteFile(apiBase, apiToken, id string, maxRetries int, retryDelay float64
 	client := &http.Client{Timeout: defaultClientTimeout}
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		if attempt > 0 {
-			backoff := time.Duration(float64(time.Second) * float64(retryDelay) * math.Pow(2, float64(attempt-1)))
-			jitter := time.Duration(rand.Float64() * float64(backoff) * 0.5)
-			sleep := backoff + jitter
-			fmt.Printf("  Retrying %s (attempt %d/%d, waiting %v)...\n", id, attempt+1, maxRetries+1, sleep)
-			time.Sleep(sleep)
-		}
-
-		url := apiBase + "/api/v1/files/" + id
-		req, err := http.NewRequest("DELETE", url, nil)
+		req, err := http.NewRequest("DELETE", apiBase+"/api/v1/files/"+id, nil)
 		if err != nil {
-			return false, http.StatusInternalServerError
-		}
-		req.Header.Set("Authorization", "Bearer "+apiToken)
-
-		resp, err := client.Do(req)
-		if err != nil {
+			if attempt == maxRetries {
+				return false, http.StatusInternalServerError
+			}
+			time.Sleep(backoff(attempt, retryDelay))
 			continue
 		}
-
+		req.Header.Set("Authorization", "Bearer "+apiToken)
+		resp, err := client.Do(req)
+		if err != nil {
+			if attempt == maxRetries {
+				return false, 0
+			}
+			time.Sleep(backoff(attempt, retryDelay))
+			continue
+		}
 		_, _ = io.ReadAll(resp.Body)
 		resp.Body.Close()
-
 		switch resp.StatusCode {
 		case http.StatusOK:
 			return true, http.StatusOK
 		case http.StatusNotFound:
 			return true, http.StatusNotFound
 		case http.StatusTooManyRequests:
-			retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
-			if retryAfter == 0 || retryAfter < defaultRateLimitDelay {
-				retryAfter = defaultRateLimitDelay
+			if attempt == maxRetries {
+				return false, http.StatusTooManyRequests
 			}
-			fmt.Printf("  Retrying %s (attempt %d/%d, waiting %v for 429)...\n", id, attempt+1, maxRetries+1, retryAfter)
-			time.Sleep(retryAfter)
+			wait := parseRetryAfter(resp.Header.Get("Retry-After"))
+			if wait == 0 {
+				wait = defaultRateLimitDelay
+			}
+			fmt.Printf("  %s rate-limited, retrying in %v (attempt %d/%d)\n", id, wait, attempt+1, maxRetries+1)
+			time.Sleep(wait)
 			continue
 		default:
-			if resp.StatusCode >= 500 {
+			if resp.StatusCode >= 500 && attempt < maxRetries {
+				time.Sleep(backoff(attempt, retryDelay))
 				continue
 			}
 			return false, resp.StatusCode
 		}
 	}
-
 	return false, http.StatusTooManyRequests
+}
+
+func backoff(attempt int, retryDelay float64) time.Duration {
+	base := time.Duration(float64(time.Second) * float64(retryDelay) * math.Pow(2, float64(attempt)))
+	return base + time.Duration(rand.Float64()*float64(base)*0.5)
 }
 
 var retryAfterRegex = regexp.MustCompile(`^([0-9]+)$`)

--- a/kubernetes/llm/components/open-webui-cleanup/cleanup-openwebui-orphans.go
+++ b/kubernetes/llm/components/open-webui-cleanup/cleanup-openwebui-orphans.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+//nolint:lll // Database connection string can be long
+const defaultDBURI = "postgres://postgres:postgres@open-webui-rw.llm.svc.cluster.local:5432/openwebui?sslmode=require"
+const defaultAPIBase = "http://open-webui.llm.svc.cluster.local:8080"
+
+func main() {
+	dryRun := flag.Bool("dry-run", false, "show what would be deleted without deleting")
+	dbURI := flag.String("db-uri", os.Getenv("DATABASE_URL"), "PostgreSQL connection URI")
+	apiToken := flag.String("api-token", os.Getenv("OWUI_API_TOKEN"), "Open WebUI API bearer token")
+	concurrency := flag.Int("concurrency", 5, "number of concurrent API deletes")
+	apiBase := flag.String("api-base", os.Getenv("OWUI_API_BASE"), "Open WebUI API base URL")
+	flag.Parse()
+
+	if *dbURI == "" {
+		fmt.Fprintln(os.Stderr, "Error: DATABASE_URL is required")
+		os.Exit(1)
+	}
+	if *apiToken == "" {
+		fmt.Fprintln(os.Stderr, "Error: OWUI_API_TOKEN is required")
+		os.Exit(1)
+	}
+
+	if *apiBase == "" {
+		*apiBase = defaultAPIBase
+	}
+
+	db, err := sql.Open("postgres", *dbURI)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "DB open: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		fmt.Fprintf(os.Stderr, "DB ping: %v\n", err)
+		os.Exit(1)
+	}
+
+	fileIDs, err := getOrphanedFileIDs(db)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Query error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(fileIDs) == 0 {
+		fmt.Println("No orphaned files found. Nothing to do.")
+		return
+	}
+
+	fmt.Printf("Found %d orphaned files.\n\n", len(fileIDs))
+
+	deleted, failed := cleanup(fileIDs, *apiBase, *apiToken, *concurrency, *dryRun)
+	fmt.Printf("Deleted: %d\nFailed: %d\n", deleted, failed)
+
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func getOrphanedFileIDs(db *sql.DB) ([]string, error) {
+	rows, err := db.Query(
+		"SELECT f.id FROM file f " +
+			"WHERE f.id NOT IN (SELECT DISTINCT file_id FROM knowledge_file) " +
+			"AND f.id NOT IN (SELECT DISTINCT cf.file_id FROM chat_file cf)",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func cleanup(fileIDs []string, apiBase, apiToken string, concurrency int, dryRun bool) (int, int) {
+	if dryRun {
+		fmt.Println("DRY RUN — nothing will be deleted.")
+		return 0, len(fileIDs)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	deleted := atomic.Int64{}
+	failed := atomic.Int64{}
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, concurrency)
+
+	for _, id := range fileIDs {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(fid string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			url := apiBase + "/api/v1/files/" + fid
+			req, err := http.NewRequest("DELETE", url, nil)
+			if err != nil {
+				failed.Add(1)
+				fmt.Fprintf(os.Stderr, "  FAIL %s: req: %v\n", fid, err)
+				return
+			}
+			req.Header.Set("Authorization", "Bearer "+apiToken)
+
+			resp, err := client.Do(req)
+			if err != nil {
+				failed.Add(1)
+				fmt.Fprintf(os.Stderr, "  FAIL %s: %v\n", fid, err)
+				return
+			}
+			defer resp.Body.Close()
+
+			body, _ := io.ReadAll(resp.Body)
+
+			switch resp.StatusCode {
+			case http.StatusOK:
+				deleted.Add(1)
+				if deleted.Load()%500 == 0 {
+					fmt.Printf("  Processed: %d deleted, %d failed so far...\n",
+						deleted.Load(), failed.Load())
+				}
+			case http.StatusNotFound:
+				deleted.Add(1)
+			default:
+				failed.Add(1)
+				msg := strings.TrimSpace(string(body))
+				if len(msg) > 200 {
+					msg = msg[:200]
+				}
+				fmt.Fprintf(os.Stderr, "  FAIL %s: %s %s\n", fid, resp.Status, msg)
+			}
+		}(id)
+	}
+
+	wg.Wait()
+	return int(deleted.Load()), int(failed.Load())
+}

--- a/kubernetes/llm/components/open-webui-cleanup/cleanup-openwebui-orphans.go
+++ b/kubernetes/llm/components/open-webui-cleanup/cleanup-openwebui-orphans.go
@@ -147,7 +147,7 @@ func deleteFile(apiBase, apiToken, id string, maxRetries int, retryDelay float64
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
-			backoff := time.Duration(float64(retryDelay) * math.Pow(2, float64(attempt-1)))
+			backoff := time.Duration(float64(time.Second) * float64(retryDelay) * math.Pow(2, float64(attempt-1)))
 			jitter := time.Duration(rand.Float64() * float64(backoff) * 0.5)
 			sleep := backoff + jitter
 			fmt.Printf("  Retrying %s (attempt %d/%d, waiting %v)...\n", id, attempt+1, maxRetries+1, sleep)

--- a/kubernetes/llm/components/open-webui-cleanup/cleanup-openwebui-orphans.go
+++ b/kubernetes/llm/components/open-webui-cleanup/cleanup-openwebui-orphans.go
@@ -5,8 +5,12 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
+	"math/rand/v2"
 	"net/http"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,16 +19,25 @@ import (
 	_ "github.com/lib/pq"
 )
 
-//nolint:lll // Database connection string can be long
-const defaultDBURI = "postgres://postgres:postgres@open-webui-rw.llm.svc.cluster.local:5432/openwebui?sslmode=require"
-const defaultAPIBase = "http://open-webui.llm.svc.cluster.local:8080"
+const (
+	defaultDBURI           = "postgres://postgres:postgres@open-webui-rw.llm.svc.cluster.local:5432/openwebui?sslmode=require"
+	defaultAPIBase         = "http://open-webui.llm.svc.cluster.local:8080"
+	defaultBatchSize       = 500
+	defaultConcurrency     = 5
+	defaultMaxRetries      = 3
+	defaultRetryDelay      = 1.0
+	defaultClientTimeout   = 30 * time.Second
+)
 
 func main() {
 	dryRun := flag.Bool("dry-run", false, "show what would be deleted without deleting")
 	dbURI := flag.String("db-uri", os.Getenv("DATABASE_URL"), "PostgreSQL connection URI")
 	apiToken := flag.String("api-token", os.Getenv("OWUI_API_TOKEN"), "Open WebUI API bearer token")
-	concurrency := flag.Int("concurrency", 5, "number of concurrent API deletes")
+	concurrency := flag.Int("concurrency", defaultConcurrency, "number of concurrent API deletes")
+	batchSize := flag.Int("batch-size", defaultBatchSize, "number of file IDs to fetch per query")
 	apiBase := flag.String("api-base", os.Getenv("OWUI_API_BASE"), "Open WebUI API base URL")
+	maxRetries := flag.Int("max-retries", defaultMaxRetries, "max HTTP retries per request")
+	retryDelay := flag.Float64("retry-delay", defaultRetryDelay, "base delay in seconds for exponential backoff")
 	flag.Parse()
 
 	if *dbURI == "" {
@@ -35,9 +48,20 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Error: OWUI_API_TOKEN is required")
 		os.Exit(1)
 	}
-
 	if *apiBase == "" {
 		*apiBase = defaultAPIBase
+	}
+	if *batchSize <= 0 {
+		fmt.Fprintln(os.Stderr, "Error: batch-size must be positive")
+		os.Exit(1)
+	}
+	if *maxRetries < 0 {
+		fmt.Fprintln(os.Stderr, "Error: max-retries must be non-negative")
+		os.Exit(1)
+	}
+	if *retryDelay <= 0 {
+		fmt.Fprintln(os.Stderr, "Error: retry-delay must be positive")
+		os.Exit(1)
 	}
 
 	db, err := sql.Open("postgres", *dbURI)
@@ -52,7 +76,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	fileIDs, err := getOrphanedFileIDs(db)
+	fileIDs, err := getOrphanedFileIDs(db, *batchSize)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Query error: %v\n", err)
 		os.Exit(1)
@@ -65,7 +89,7 @@ func main() {
 
 	fmt.Printf("Found %d orphaned files.\n\n", len(fileIDs))
 
-	deleted, failed := cleanup(fileIDs, *apiBase, *apiToken, *concurrency, *dryRun)
+	deleted, failed := cleanup(fileIDs, *apiBase, *apiToken, *concurrency, *maxRetries, *retryDelay, *dryRun)
 	fmt.Printf("Deleted: %d\nFailed: %d\n", deleted, failed)
 
 	if failed > 0 {
@@ -73,11 +97,31 @@ func main() {
 	}
 }
 
-func getOrphanedFileIDs(db *sql.DB) ([]string, error) {
+func getOrphanedFileIDs(db *sql.DB, batchSize int) ([]string, error) {
+	var allIDs []string
+
+	for {
+		batch, err := fetchBatch(db, batchSize, len(allIDs))
+		if err != nil {
+			return nil, err
+		}
+		if len(batch) == 0 {
+			break
+		}
+		allIDs = append(allIDs, batch...)
+	}
+
+	return allIDs, nil
+}
+
+func fetchBatch(db *sql.DB, batchSize, offset int) ([]string, error) {
 	rows, err := db.Query(
-		"SELECT f.id FROM file f " +
-			"WHERE f.id NOT IN (SELECT DISTINCT file_id FROM knowledge_file) " +
-			"AND f.id NOT IN (SELECT DISTINCT cf.file_id FROM chat_file cf)",
+		"SELECT f.id FROM file f "+
+			"WHERE f.id NOT IN (SELECT DISTINCT file_id FROM knowledge_file) "+
+			"AND f.id NOT IN (SELECT DISTINCT cf.file_id FROM chat_file cf) "+
+			"ORDER BY f.id "+
+			"LIMIT $1 OFFSET $2",
+		batchSize, offset,
 	)
 	if err != nil {
 		return nil, err
@@ -92,16 +136,82 @@ func getOrphanedFileIDs(db *sql.DB) ([]string, error) {
 		}
 		ids = append(ids, id)
 	}
-	return ids, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
-func cleanup(fileIDs []string, apiBase, apiToken string, concurrency int, dryRun bool) (int, int) {
+func deleteFile(apiBase, apiToken, id string, maxRetries int, retryDelay float64) (deleted bool, status int) {
+	client := &http.Client{Timeout: defaultClientTimeout}
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(float64(retryDelay) * math.Pow(2, float64(attempt-1)))
+			jitter := time.Duration(rand.Float64() * float64(backoff) * 0.5)
+			sleep := backoff + jitter
+			fmt.Printf("  Retrying %s (attempt %d/%d, waiting %v)...\n", id, attempt+1, maxRetries+1, sleep)
+			time.Sleep(sleep)
+		}
+
+		url := apiBase + "/api/v1/files/" + id
+		req, err := http.NewRequest("DELETE", url, nil)
+		if err != nil {
+			return false, http.StatusInternalServerError
+		}
+		req.Header.Set("Authorization", "Bearer "+apiToken)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			continue
+		}
+
+		_, _ = io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		switch resp.StatusCode {
+		case http.StatusOK:
+			return true, http.StatusOK
+		case http.StatusNotFound:
+			return true, http.StatusNotFound
+		case http.StatusTooManyRequests:
+			retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+			if retryAfter > 0 && retryAfter > time.Duration(retryDelay*float64(time.Second)) {
+				retryAfter = time.Duration(retryDelay * float64(time.Second))
+			}
+			time.Sleep(retryAfter)
+			continue
+		default:
+			if resp.StatusCode >= 500 {
+				continue
+			}
+			return false, resp.StatusCode
+		}
+	}
+
+	return false, http.StatusTooManyRequests
+}
+
+var retryAfterRegex = regexp.MustCompile(`^([0-9]+)$`)
+
+func parseRetryAfter(header string) time.Duration {
+	if header == "" {
+		return 0
+	}
+	if matches := retryAfterRegex.FindStringSubmatch(strings.TrimSpace(header)); matches != nil {
+		if seconds, err := strconv.ParseInt(matches[1], 10, 64); err == nil {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+	return 0
+}
+
+func cleanup(fileIDs []string, apiBase, apiToken string, concurrency, maxRetries int, retryDelay float64, dryRun bool) (int, int) {
 	if dryRun {
 		fmt.Println("DRY RUN — nothing will be deleted.")
 		return 0, len(fileIDs)
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
 	deleted := atomic.Int64{}
 	failed := atomic.Int64{}
 
@@ -115,41 +225,16 @@ func cleanup(fileIDs []string, apiBase, apiToken string, concurrency int, dryRun
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			url := apiBase + "/api/v1/files/" + fid
-			req, err := http.NewRequest("DELETE", url, nil)
-			if err != nil {
-				failed.Add(1)
-				fmt.Fprintf(os.Stderr, "  FAIL %s: req: %v\n", fid, err)
-				return
-			}
-			req.Header.Set("Authorization", "Bearer "+apiToken)
-
-			resp, err := client.Do(req)
-			if err != nil {
-				failed.Add(1)
-				fmt.Fprintf(os.Stderr, "  FAIL %s: %v\n", fid, err)
-				return
-			}
-			defer resp.Body.Close()
-
-			body, _ := io.ReadAll(resp.Body)
-
-			switch resp.StatusCode {
-			case http.StatusOK:
+			ok, _ := deleteFile(apiBase, apiToken, fid, maxRetries, retryDelay)
+			if ok {
 				deleted.Add(1)
 				if deleted.Load()%500 == 0 {
 					fmt.Printf("  Processed: %d deleted, %d failed so far...\n",
 						deleted.Load(), failed.Load())
 				}
-			case http.StatusNotFound:
-				deleted.Add(1)
-			default:
+			} else {
 				failed.Add(1)
-				msg := strings.TrimSpace(string(body))
-				if len(msg) > 200 {
-					msg = msg[:200]
-				}
-				fmt.Fprintf(os.Stderr, "  FAIL %s: %s %s\n", fid, resp.Status, msg)
+				fmt.Fprintf(os.Stderr, "  FAIL %s\n", fid)
 			}
 		}(id)
 	}

--- a/kubernetes/llm/components/open-webui-cleanup/cleanup-openwebui-orphans.go
+++ b/kubernetes/llm/components/open-webui-cleanup/cleanup-openwebui-orphans.go
@@ -24,8 +24,8 @@ const (
 	defaultAPIBase         = "http://open-webui.llm.svc.cluster.local:8080"
 	defaultBatchSize       = 500
 	defaultConcurrency     = 5
-	defaultMaxRetries      = 3
-	defaultRetryDelay      = 1.0
+	defaultMaxRetries      = 1
+	defaultRetryDelay      = 2.0
 	defaultClientTimeout   = 30 * time.Second
 )
 
@@ -91,10 +91,6 @@ func main() {
 
 	deleted, failed := cleanup(fileIDs, *apiBase, *apiToken, *concurrency, *maxRetries, *retryDelay, *dryRun)
 	fmt.Printf("Deleted: %d\nFailed: %d\n", deleted, failed)
-
-	if failed > 0 {
-		os.Exit(1)
-	}
 }
 
 func getOrphanedFileIDs(db *sql.DB, batchSize int) ([]string, error) {
@@ -225,7 +221,7 @@ func cleanup(fileIDs []string, apiBase, apiToken string, concurrency, maxRetries
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			ok, _ := deleteFile(apiBase, apiToken, fid, maxRetries, retryDelay)
+			ok, status := deleteFile(apiBase, apiToken, fid, maxRetries, retryDelay)
 			if ok {
 				deleted.Add(1)
 				if deleted.Load()%500 == 0 {
@@ -234,7 +230,7 @@ func cleanup(fileIDs []string, apiBase, apiToken string, concurrency, maxRetries
 				}
 			} else {
 				failed.Add(1)
-				fmt.Fprintf(os.Stderr, "  FAIL %s\n", fid)
+				fmt.Fprintf(os.Stderr, "  FAIL %s (status %d)\n", fid, status)
 			}
 		}(id)
 	}

--- a/kubernetes/llm/components/open-webui-cleanup/cleanup-openwebui-orphans.go
+++ b/kubernetes/llm/components/open-webui-cleanup/cleanup-openwebui-orphans.go
@@ -23,10 +23,11 @@ const (
 	defaultDBURI           = "postgres://postgres:postgres@open-webui-rw.llm.svc.cluster.local:5432/openwebui?sslmode=require"
 	defaultAPIBase         = "http://open-webui.llm.svc.cluster.local:8080"
 	defaultBatchSize       = 500
-	defaultConcurrency     = 5
+	defaultConcurrency     = 1
 	defaultMaxRetries      = 1
-	defaultRetryDelay      = 2.0
+	defaultRetryDelay      = 5.0
 	defaultClientTimeout   = 30 * time.Second
+	defaultRateLimitDelay  = 5 * time.Second
 )
 
 func main() {
@@ -172,9 +173,10 @@ func deleteFile(apiBase, apiToken, id string, maxRetries int, retryDelay float64
 			return true, http.StatusNotFound
 		case http.StatusTooManyRequests:
 			retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
-			if retryAfter > 0 && retryAfter > time.Duration(retryDelay*float64(time.Second)) {
-				retryAfter = time.Duration(retryDelay * float64(time.Second))
+			if retryAfter == 0 || retryAfter < defaultRateLimitDelay {
+				retryAfter = defaultRateLimitDelay
 			}
+			fmt.Printf("  Retrying %s (attempt %d/%d, waiting %v for 429)...\n", id, attempt+1, maxRetries+1, retryAfter)
 			time.Sleep(retryAfter)
 			continue
 		default:
@@ -212,27 +214,26 @@ func cleanup(fileIDs []string, apiBase, apiToken string, concurrency, maxRetries
 	failed := atomic.Int64{}
 
 	var wg sync.WaitGroup
-	sem := make(chan struct{}, concurrency)
+	sem := make(chan struct{}, 1)
 
-	for _, id := range fileIDs {
+	for i, id := range fileIDs {
 		wg.Add(1)
-		sem <- struct{}{}
-		go func(fid string) {
+		go func(idx int, fid string) {
 			defer wg.Done()
-			defer func() { <-sem }()
-
+			sem <- struct{}{}
 			ok, status := deleteFile(apiBase, apiToken, fid, maxRetries, retryDelay)
+			<-sem
 			if ok {
 				deleted.Add(1)
-				if deleted.Load()%500 == 0 {
-					fmt.Printf("  Processed: %d deleted, %d failed so far...\n",
-						deleted.Load(), failed.Load())
+				if idx%50 == 0 {
+					fmt.Printf("  Progress: %d/%d deleted, %d failed so far...\n",
+						deleted.Load(), idx, failed.Load())
 				}
 			} else {
 				failed.Add(1)
 				fmt.Fprintf(os.Stderr, "  FAIL %s (status %d)\n", fid, status)
 			}
-		}(id)
+		}(i, id)
 	}
 
 	wg.Wait()

--- a/kubernetes/llm/components/open-webui-cleanup/cronjob.yaml
+++ b/kubernetes/llm/components/open-webui-cleanup/cronjob.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: open-webui-cleanup
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+    gitops-ci.k8s.io/exempt-image-checksum: "registry.arthurvardevanyan.com/homelab/toolbox:not_latest"
+  labels:
+    app: open-webui-cleanup
+spec:
+  schedule: "0 3 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  suspend: true
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      activeDeadlineSeconds: 7200
+      completionMode: NonIndexed
+      template:
+        metadata:
+          labels:
+            app: open-webui-cleanup
+        spec:
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          automountServiceAccountToken: false
+          enableServiceLinks: false
+          dnsPolicy: ClusterFirst
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: cleanup
+              image: registry.arthurvardevanyan.com/homelab/toolbox:not_latest
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - "-c"
+                - |
+                  set -o errexit
+                  set -o nounset
+                  set -o pipefail
+
+                  SCRIPT_DIR=/scripts
+                  cd "$SCRIPT_DIR"
+                  echo "running open-webui orphan cleanup ..."
+                  go run .
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: 256Mi
+                limits:
+                  cpu: "500m"
+                  memory: 512Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                privileged: false
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+                capabilities:
+                  drop:
+                    - ALL
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: open-webui-app
+                      key: fqdn-uri
+                - name: OWUI_API_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: oikb
+                      key: OPEN_WEBUI_API_KEY
+          volumes:
+            - name: scripts
+              configMap:
+                name: open-webui-cleanup

--- a/kubernetes/llm/components/open-webui-cleanup/cronjob.yaml
+++ b/kubernetes/llm/components/open-webui-cleanup/cronjob.yaml
@@ -14,7 +14,7 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
-  suspend: true
+  suspend: false
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:

--- a/kubernetes/llm/components/open-webui-cleanup/cronjob.yaml
+++ b/kubernetes/llm/components/open-webui-cleanup/cronjob.yaml
@@ -18,7 +18,7 @@ spec:
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
-      backoffLimit: 3
+      backoffLimit: 0
       activeDeadlineSeconds: 7200
       completionMode: NonIndexed
       template:

--- a/kubernetes/llm/components/open-webui-cleanup/cronjob.yaml
+++ b/kubernetes/llm/components/open-webui-cleanup/cronjob.yaml
@@ -54,6 +54,10 @@ spec:
               volumeMounts:
                 - name: scripts
                   mountPath: /scripts
+                - name: gocache
+                  mountPath: /tmp/go-build
+                - name: gomodcache
+                  mountPath: /tmp/go-mod
               resources:
                 requests:
                   cpu: "100m"
@@ -72,6 +76,10 @@ spec:
                   drop:
                     - ALL
               env:
+                - name: GOCACHE
+                  value: /tmp/go-build
+                - name: GOMODCACHE
+                  value: /tmp/go-mod
                 - name: DATABASE_URL
                   valueFrom:
                     secretKeyRef:
@@ -86,3 +94,7 @@ spec:
             - name: scripts
               configMap:
                 name: open-webui-cleanup
+            - name: gocache
+              emptyDir: {}
+            - name: gomodcache
+              emptyDir: {}

--- a/kubernetes/llm/components/open-webui-cleanup/go.mod
+++ b/kubernetes/llm/components/open-webui-cleanup/go.mod
@@ -1,0 +1,5 @@
+module openwebui-orphan-cleanup
+
+go 1.25
+
+require github.com/lib/pq v1.10.9

--- a/kubernetes/llm/components/open-webui-cleanup/go.sum
+++ b/kubernetes/llm/components/open-webui-cleanup/go.sum
@@ -1,0 +1,2 @@
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/kubernetes/llm/components/open-webui-cleanup/kustomization.yaml
+++ b/kubernetes/llm/components/open-webui-cleanup/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - cronjob.yaml
+  - network-policy.yaml
+generatorOptions: {}
+configMapGenerator:
+  - files:
+      - cleanup-openwebui-orphans.go
+      - go.mod
+      - go.sum
+    name: open-webui-cleanup
+    namespace: llm

--- a/kubernetes/llm/components/open-webui-cleanup/kustomization.yaml
+++ b/kubernetes/llm/components/open-webui-cleanup/kustomization.yaml
@@ -4,7 +4,8 @@ kind: Component
 resources:
   - cronjob.yaml
   - network-policy.yaml
-generatorOptions: {}
+generatorOptions:
+  disableNameSuffixHash: true
 configMapGenerator:
   - files:
       - cleanup-openwebui-orphans.go

--- a/kubernetes/llm/components/open-webui-cleanup/network-policy.yaml
+++ b/kubernetes/llm/components/open-webui-cleanup/network-policy.yaml
@@ -38,6 +38,16 @@ spec:
         - protocol: TCP
           port: 5432
     - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: llm
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: open-webui
+      ports:
+        - protocol: TCP
+          port: 8080
+    - to:
         - ipBlock:
             cidr: 0.0.0.0/0
             except:

--- a/kubernetes/llm/components/open-webui-cleanup/network-policy.yaml
+++ b/kubernetes/llm/components/open-webui-cleanup/network-policy.yaml
@@ -16,6 +16,28 @@ spec:
       app: open-webui-cleanup
   egress:
     - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+          podSelector:
+            matchLabels:
+              dns.operator.openshift.io/daemonset-dns: default
+      ports:
+        - port: 5353
+          protocol: UDP
+        - port: 5353
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: llm
+          podSelector:
+            matchLabels:
+              cnpg.io/cluster: open-webui
+      ports:
+        - protocol: TCP
+          port: 5432
+    - to:
         - ipBlock:
             cidr: 0.0.0.0/0
             except:

--- a/kubernetes/llm/components/open-webui-cleanup/network-policy.yaml
+++ b/kubernetes/llm/components/open-webui-cleanup/network-policy.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-internet-egress-open-webui-cleanup
+  namespace: llm
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app: open-webui-cleanup
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app: open-webui-cleanup
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+        - ipBlock:
+            cidr: 10.101.10.5/32 # OKD WildCard
+        - ipBlock:
+            cidr: 10.101.10.7/32 # OKD APP WildCard

--- a/kubernetes/llm/overlays/okd/kustomization.yaml
+++ b/kubernetes/llm/overlays/okd/kustomization.yaml
@@ -19,3 +19,4 @@ components:
   - ../../components/searxng
   - ../../components/otel-collector
   - ../../components/oikb
+  - ../../components/open-webui-cleanup


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

Migrate the Open WebUI orphan cleanup from a Python script + base64-encoded archive to a Go-based Kubernetes CronJob using Kustomize `configMapGenerator`.

## Changes

### New files
- `kubernetes/llm/components/open-webui-cleanup/` — component directory
  - `cleanup-openwebui-orphans.go` — Go source (queries DB, deletes orphans via API)
  - `go.mod` / `go.sum` — Go module definitions
  - `cronjob.yaml` — CronJob spec (schedule: Sundays 03:00, suspended by default)
  - `kustomization.yaml` — Component with `configMapGenerator` + `files:`
  - `network-policy.yaml` — Internet egress for Go module downloads

### Modified files
- `kubernetes/llm/components/cnpg-open-webui/network-policy.yaml` — added ingress rule for cleanup pods to DB
- `kubernetes/llm/overlays/okd/kustomization.yaml` — references new component

### Architecture
- Source files injected into a ConfigMap via Kustomize `configMapGenerator`
- CronJob mounts ConfigMap as `/scripts` and runs `go run .`
- Runtime Go module downloads (internet egress allowed)
- DB credentials sourced from existing CNPG `open-webui-app` secret
- API token sourced from existing `oikb` secret

### Image pinning
- Exempted via annotation (same pattern as model-downloader)


___

### **PR Type**
Enhancement


___

### **Description**
- Migrate orphan cleanup from Python to Go CronJob

- Inject Go source into CronJob via configMapGenerator

- Implement batched DB queries with API exponential backoff

- Add network policies for DNS, database, and internet


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Kustomize["kustomization.yaml"] --> configMap["configMapGenerator"]
  configMap --> CronJob["cronjob.yaml"]
  CronJob --> GoCode["cleanup-openwebui-orphans.go"]
  GoCode --> DB["PostgreSQL"]
  GoCode --> API["Open WebUI API"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>network-policy.yaml</strong><dd><code>Add ingress rule for cleanup pods to DB</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/721/files#diff-977d157562d3c67dd766e87b8b5f6909a03599bc0e2d76c2f44fe48ce81d2842">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>kustomization.yaml</strong><dd><code>Configure Kustomize component with configMapGenerator</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/721/files#diff-271a1554a737290acd5d11f2d5da64508b77beab02a82f194c3b693100d70045">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>network-policy.yaml</strong><dd><code>Define egress rules for DNS, DB, API, and internet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/721/files#diff-b2180ccb4ce9cd8e534c43df899c25b598b5653ce4a94c6c8c471256ee15b51c">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>kustomization.yaml</strong><dd><code>Reference new open-webui-cleanup component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/721/files#diff-2d73b5d8535f4fb9927fb46cc78612f905045ac47437eb32615dfb8cd28a2d00">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>cronjob.yaml</strong><dd><code>Define CronJob spec with Go runtime execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/721/files#diff-ada7c5a2eace8c0079d496f6e4d7c0d6fa28571e57bbd271dc56c4d923f02aba">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cleanup-openwebui-orphans.go</strong><dd><code>Implement batched DB queries and API cleanup logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/721/files#diff-e8255013a76de834dbc434bb37789052c6a6e0b20ed123cd747152df8982b774">+245/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>go.mod</strong><dd><code>Define Go module dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/721/files#diff-b8d2ffb28deb2dd7f4a961b847d87047cd84c5369bd7065dd509d8b0ad798697">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>⚙️ Agent run details</strong></summary>

- Model: openai/qwen3.6-35b-a3b
- Tokens: 8,951 in / 6,067 out / 15,018 total
- Time cost: 80.8s
- AI calls: 1

</details>
