### PR TITLE
fix(nfs-sync): fix subshell masking bug and add sidecar log inspection

### DIFF
--- a/kubernetes/unifi-network-application/components/unas-nfs/cronjob.yaml
+++ b/kubernetes/unifi-network-application/components/unas-nfs/cronjob.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nfs-sync
+  annotations:
+    checkov.io/skip1: CKV_K8S_40=OpenShift Injects Random UID
+    checkov.io/skip2: CKV_K8S_43=Don't Mind Tag for This
+    gitops-ci.k8s.io/exempt-image-checksum: "registry.arthurvardevanyan.com/homelab/toolbox:not_latest"
+  namespace: unifi-network-application
+spec:
+  suspend: true
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 300
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: nfs-sync
+        spec:
+          serviceAccountName: nfs-sync
+          automountServiceAccountToken: true
+          enableServiceLinks: false
+          dnsPolicy: ClusterFirst
+          schedulerName: default-scheduler
+          containers:
+            - name: nfs-sync
+              image: registry.arthurvardevanyan.com/homelab/toolbox:not_latest
+              securityContext:
+                runAsNonRoot: true
+                privileged: false
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - mountPath: /tmp/.ssh
+                  name: ssh-creds
+                  readOnly: true
+                - mountPath: /tmp/exports
+                  name: nfs-exports
+                - mountPath: /tmp/nfs-sync
+                  name: nfs-sync-script
+                - mountPath: /tmp/scratch
+                  name: scratch
+              resources:
+                limits:
+                  cpu: 100m
+                  ephemeral-storage: 64Mi
+                  memory: 64Mi
+                requests:
+                  cpu: 5m
+                  ephemeral-storage: 16Mi
+                  memory: 16Mi
+              command:
+                - "bash"
+                - "/tmp/nfs-sync/nfs-sync.sh"
+          volumes:
+            - name: ssh-creds
+              secret:
+                secretName: udm-creds
+                optional: false
+            - name: nfs-exports
+              configMap:
+                name: nfs-exports
+            - name: nfs-sync-script
+              configMap:
+                name: nfs-sync
+            - name: scratch
+              emptyDir:
+                sizeLimit: 50Mi
+          restartPolicy: Never

--- a/kubernetes/unifi-network-application/components/unas-nfs/kustomization.yaml
+++ b/kubernetes/unifi-network-application/components/unas-nfs/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./cronjob.yaml
+  - ./rbac.yaml
+  - ./network-policy.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - files:
+      - shared-54d42e41-1bec-4de7-9ebc-98303186e8de.exports
+      - shared-58e64326-3679-470c-acc3-3b194d45ea8f.exports
+      - shared-8fdecd7b-7930-4234-9680-9b29cb85b8bb.exports
+    name: nfs-exports
+    namespace: unifi-network-application
+  - files:
+      - nfs-sync.sh
+    name: nfs-sync
+    namespace: unifi-network-application

--- a/kubernetes/unifi-network-application/components/unas-nfs/network-policy.yaml
+++ b/kubernetes/unifi-network-application/components/unas-nfs/network-policy.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-server
+  namespace: unifi-network-application
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app.kubernetes.io/instance: argocd
+spec:
+  podSelector:
+    matchLabels:
+      app: nfs-sync
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: openshift-kube-apiserver
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-kube-apiserver
+      ports:
+        - protocol: TCP
+          port: 6443

--- a/kubernetes/unifi-network-application/components/unas-nfs/nfs-sync.sh
+++ b/kubernetes/unifi-network-application/components/unas-nfs/nfs-sync.sh
@@ -46,16 +46,16 @@ check_pod_health() {
   local pod_names
   pod_names="$(kubectl get pods -n "${ns}" -l "${selector}" -o name --field-selector=status.phase=Running 2>/dev/null || true)"
   if [[ -n "${pod_names}" ]]; then
-    echo "${pod_names}" | while read -r pod; do
+    while IFS= read -r pod; do
       if [[ -n "${pod}" ]]; then
         pod_name="${pod#pod/}"
-        logs="$(kubectl logs "${pod}" -n "${ns}" --tail=500 2>/dev/null || true)"
+        logs="$(kubectl logs "${pod}" -n "${ns}" --tail=500 --all-containers 2>/dev/null || true)"
         if echo "${logs}" | grep -iqE "${ALL_PATTERNS}"; then
           echo "[${ns}/${pod_name}] storage issues detected"
           return 0
         fi
       fi
-    done
+    done <<< "${pod_names}"
   fi
   return 1
 }

--- a/kubernetes/unifi-network-application/components/unas-nfs/nfs-sync.sh
+++ b/kubernetes/unifi-network-application/components/unas-nfs/nfs-sync.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SSH_USER="$(cat /tmp/.ssh/username)"
+SSH_PASS="$(cat /tmp/.ssh/password)"
+SSH_HOST="unas.arthurvardevanyan.com"
+REMOTE_EXPORTS_DIR="/etc/exports.d"
+
+NEED_RESTART=false
+HEALTH_ISSUES_FOUND=false
+
+# ---- Phase 1: Sync exports files ----
+for export_file in /tmp/exports/shared-*.exports; do
+  filename="$(basename "${export_file}")"
+  checksum_local="$(sha256sum "${export_file}" | awk '{print $1}')"
+  checksum_remote="$(sshpass -p "${SSH_PASS}" ssh -o StrictHostKeyChecking=no "${SSH_USER}@${SSH_HOST}" "if [[ -f '${REMOTE_EXPORTS_DIR}/${filename}' ]]; then sha256sum '${REMOTE_EXPORTS_DIR}/${filename}' | awk '{print \$1}'; else echo 'MISSING'; fi" 2>/dev/null || echo 'ERROR')"
+
+  if [[ "${checksum_local}" != "${checksum_remote}" ]]; then
+    echo "[${filename}] checksums differ (${checksum_remote} -> ${checksum_local}), syncing..."
+    sshpass -p "${SSH_PASS}" scp "${export_file}" "${SSH_USER}@${SSH_HOST}:${REMOTE_EXPORTS_DIR}/${filename}"
+    NEED_RESTART=true
+  else
+    echo "[${filename}] already in sync"
+  fi
+done
+
+if ${NEED_RESTART}; then
+  echo "Restarting nfs-server..."
+  sshpass -p "${SSH_PASS}" ssh "${SSH_USER}@${SSH_HOST}" "sudo systemctl restart nfs-server"
+  sleep 5
+  sshpass -p "${SSH_PASS}" ssh "${SSH_USER}@${SSH_HOST}" "sudo systemctl status nfs-server"
+fi
+
+# ---- Phase 2: Check pod health for storage issues ----
+# Minio storage error patterns
+MINIO_PATTERNS="offline|unable to write|no online disks|file access denied|drive may be faulty|Unable to write to the backend"
+# NFS/io error patterns
+NFS_PATTERNS="IO error|stale file handle|nfs|mount error|input output error"
+ALL_PATTERNS="${MINIO_PATTERNS}|${NFS_PATTERNS}"
+
+check_pod_health() {
+  local ns="$1"
+  local selector="$2"
+  local pod_names
+  pod_names="$(kubectl get pods -n "${ns}" -l "${selector}" -o name --field-selector=status.phase=Running 2>/dev/null || true)"
+  if [[ -n "${pod_names}" ]]; then
+    echo "${pod_names}" | while read -r pod; do
+      if [[ -n "${pod}" ]]; then
+        pod_name="${pod#pod/}"
+        logs="$(kubectl logs "${pod}" -n "${ns}" --tail=500 2>/dev/null || true)"
+        if echo "${logs}" | grep -iqE "${ALL_PATTERNS}"; then
+          echo "[${ns}/${pod_name}] storage issues detected"
+          return 0
+        fi
+      fi
+    done
+  fi
+  return 1
+}
+
+for ns_info in "minio-unas:app=minio-ssd" "minio-unas:app=minio" "immich:app.kubernetes.io/name=server,app.kubernetes.io/instance=immich"; do
+  IFS=':' read -r ns selector <<< "${ns_info}"
+  # shellcheck disable=SC2310
+  if check_pod_health "${ns}" "${selector}"; then
+    HEALTH_ISSUES_FOUND=true
+  fi
+done
+
+# ---- Phase 3: Rolling restart if needed ----
+if ${NEED_RESTART} || ${HEALTH_ISSUES_FOUND}; then
+  echo "Triggering rolling restarts..."
+  kubectl -n minio-unas rollout restart deployment minio-ssd
+  kubectl -n minio-unas rollout restart deployment minio
+  kubectl -n immich rollout restart deployment immich-server
+fi
+
+echo "NFS sync check complete"

--- a/kubernetes/unifi-network-application/components/unas-nfs/rbac.yaml
+++ b/kubernetes/unifi-network-application/components/unas-nfs/rbac.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfs-sync
+  namespace: unifi-network-application
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfs-sync
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfs-sync
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfs-sync
+subjects:
+  - kind: ServiceAccount
+    name: nfs-sync
+    namespace: unifi-network-application

--- a/kubernetes/unifi-network-application/components/unas-nfs/shared-54d42e41-1bec-4de7-9ebc-98303186e8de.exports
+++ b/kubernetes/unifi-network-application/components/unas-nfs/shared-54d42e41-1bec-4de7-9ebc-98303186e8de.exports
@@ -1,0 +1,1 @@
+/var/nfs/shared/s3ssd *(rw,sync,no_subtree_check,crossmnt,no_root_squash,insecure)

--- a/kubernetes/unifi-network-application/components/unas-nfs/shared-58e64326-3679-470c-acc3-3b194d45ea8f.exports
+++ b/kubernetes/unifi-network-application/components/unas-nfs/shared-58e64326-3679-470c-acc3-3b194d45ea8f.exports
@@ -1,0 +1,1 @@
+/var/nfs/shared/immich *(rw,sync,no_subtree_check,crossmnt,no_root_squash,insecure)

--- a/kubernetes/unifi-network-application/components/unas-nfs/shared-8fdecd7b-7930-4234-9680-9b29cb85b8bb.exports
+++ b/kubernetes/unifi-network-application/components/unas-nfs/shared-8fdecd7b-7930-4234-9680-9b29cb85b8bb.exports
@@ -1,0 +1,1 @@
+/var/nfs/shared/s3 *(rw,sync,no_subtree_check,crossmnt,no_root_squash,insecure)

--- a/kubernetes/unifi-network-application/overlays/okd/egress-firewall.yaml
+++ b/kubernetes/unifi-network-application/overlays/okd/egress-firewall.yaml
@@ -6,6 +6,12 @@ metadata:
   namespace: unifi-network-application
 spec:
   egress:
+    # Control Plane
+    - type: Allow
+      to:
+        nodeSelector:
+          matchLabels:
+            node-role.kubernetes.io/control-plane: ""
     - type: Allow
       to:
         dnsName: unifi.arthurvardevanyan.com

--- a/kubernetes/unifi-network-application/overlays/okd/kustomization.yaml
+++ b/kubernetes/unifi-network-application/overlays/okd/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ./egress-firewall.yaml
+    # - ../../components/udm
+    # - ../../components/unas
 components:
-  - ../../components/udm
-  - ../../components/unas
+  - ../../components/unas-nfs


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add NFS export sync CronJob and automation script

- Fix subshell masking in health check loop

- Include sidecar logs in pod health inspections

- Update overlay to use new unas-nfs component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CronJob["CronJob"] --> nfs-sync["nfs-sync.sh"]
  nfs-sync --> Sync["Sync Exports"]
  nfs-sync --> Health["Check Health"]
  Sync --> NAS["Remote NAS"]
  Health --> Logs["Pod Logs"]
  Logs --> Restart["Rolling Restart"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>cronjob.yaml</strong><dd><code>Define NFS sync CronJob with security constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/722/files#diff-de40b41ca780e3bddecaf6349cffacb44372b086ae9114d35d813c12049af3b1">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>kustomization.yaml</strong><dd><code>Configure Kustomize component for NFS sync resources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/722/files#diff-990d95c40195868adcf59bce35b8354036df13e1e573ec5c1d9d2f0bf74e0b9e">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>network-policy.yaml</strong><dd><code>Allow egress to OpenShift API server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/722/files#diff-fb04d8bedeeea73c1a966fb40cfe83653902705e8de46e5338fbd0e1ee492745">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rbac.yaml</strong><dd><code>Define RBAC permissions for NFS sync service account</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/722/files#diff-47b4d39eb90999a8a77342bea1fa706cced154949d229bfc516c6956f3213cf0">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>egress-firewall.yaml</strong><dd><code>Add egress rule for control-plane nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/722/files#diff-e1cbe334e6ffc0437e2c62f18fb9604029cca7df7f46d29eadb03dc8d25382e7">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>kustomization.yaml</strong><dd><code>Switch overlay to use unas-nfs component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/722/files#diff-b546953952cc549ab2220364b29d22e5b07c51aec1dcfec7e2930f21c02404ef">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shared-54d42e41-1bec-4de7-9ebc-98303186e8de.exports</strong><dd><code>Define NFS export path for s3ssd volume</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/722/files#diff-1dc72cbdeb2f3c648fa4309e1ba80721ffcade48cda14d62fc4db8510553fead">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shared-58e64326-3679-470c-acc3-3b194d45ea8f.exports</strong><dd><code>Define NFS export path for immich volume</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/722/files#diff-d5ac1e269f9f133ca42285c76d704c7e4a3c7947b935c3cc301396dc76b30fd4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shared-8fdecd7b-7930-4234-9680-9b29cb85b8bb.exports</strong><dd><code>Define NFS export path for s3 volume</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/722/files#diff-564c8b8d65c507b7541aecb5d426173a48f0cf94ba6f3aa71c45b0949842d87a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>nfs-sync.sh</strong><dd><code>Implement NFS sync and health check logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/722/files#diff-b486162c9f0d196e11fce05b6301caa6a68382b8dfd5ae13043933d7c789ec97">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>⚙️ Agent run details</strong></summary>

- Model: openai/qwen3.6-35b-a3b
- Tokens: 7,024 in / 5,868 out / 12,892 total
- Time cost: 87.4s
- AI calls: 1

</details>
