### PR TITLE
feat(loki-operator): pin all operator images with SHA

### DIFF
--- a/kubernetes/loki-operator/base/subscription.yaml
+++ b/kubernetes/loki-operator/base/subscription.yaml
@@ -2,6 +2,8 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
+  annotations:
+    gitops-ci.k8s.io/exempt-image-checksum: quay.io/openshift-logging/passthrough-gateway
   labels:
     operators.coreos.com/loki-operator.loki-operator: ""
   name: loki-operator
@@ -14,6 +16,18 @@ spec:
   sourceNamespace: openshift-marketplace
   startingCSV: loki-operator.v0.11.0
   config:
+    env:
+      - name: RELATED_IMAGE_LOKI
+        # renovate: datasource=docker depName=docker.io/grafana/loki
+        value: docker.io/grafana/loki:3.7.7@sha256:d70e4659623f3e109af669cae76fe2a5dd5be545e2298fe8aed380d982fbc2500
+      - name: RELATED_IMAGE_GATEWAY
+        # renovate: datasource=docker depName=quay.io/observatorium/api
+        value: quay.io/observatorium/api:main-2026-08-26-a697b5a@sha256:9ef190d77510f62549d2ea4d387158091248a6ba335bf728d6b564305f74266d
+      - name: RELATED_IMAGE_OPA
+        # renovate: datasource=docker depName=quay.io/observatorium/opa-openshift
+        value: quay.io/observatorium/opa-openshift:main-2026-08-31-79de16d@sha256:08fe2069d24c1f2c2c9762694284985bd0b1a17d72c18402965dd0895fa5fff8
+      - name: RELATED_IMAGE_PASSTHROUGH_GATEWAY
+        value: quay.io/openshift-logging/passthrough-gateway:latest
     resources:
       limits:
         cpu: 50m


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Changes

Pin all loki-operator env vars to specific image versions with SHA-256 digests for immutable image references:

| Env Var | Image | Tag | Digest |
|---|---|---|---|
| RELATED_IMAGE_LOKI | docker.io/grafana/loki | 3.7.7 | `sha256:d70e4659…` |
| RELATED_IMAGE_GATEWAY | quay.io/observatorium/api | main-2026-08-26-a697b5a | `sha256:9ef190d7…` |
| RELATED_IMAGE_OPA | quay.io/observatorium/opa-openshift | main-2026-08-31-79de16d | `sha256:08fe2069…` |
| RELATED_IMAGE_PASSTHROUGH_GATEWAY | quay.io/openshift-logging/passthrough-gateway | latest | _(exempted via annotation — no versioned tags available)_ |

## Renovate Support

- Added `# renovate: datasource=docker` comments for auto-update on the 3 images with SHA pins
- passthrough-gateway has no versioned tags so no renovate annotation

## Exemptions

- Added `gitops-ci.k8s.io/exempt-image-checksum: quay.io/openshift-logging/passthrough-gateway` annotation since passthrough-gateway only has a `latest` tag with no version pin


___

### **PR Type**
Enhancement


___

### **Description**
- Pin operator images to SHA-256 digests

- Add Renovate annotations for automated updates

- Configure GitOps CI exemption for passthrough-gateway

- Update Loki operator subscription with env vars


___

### Diagram Walkthrough


```mermaid
flowchart LR
  sub["subscription.yaml"] --> env["env vars"]
  env --> sha["SHA-256 digests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>subscription.yaml</strong><dd><code>Pin operator images to SHA-256 digests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kubernetes/loki-operator/base/subscription.yaml

<ul><li>Added <code>gitops-ci</code> exemption annotation for passthrough-gateway<br> <li> Pinned <code>RELATED_IMAGE_LOKI</code>, <code>GATEWAY</code>, and <code>OPA</code> to SHA-256 digests<br> <li> Added Renovate datasource comments for automated updates<br> <li> Set <code>RELATED_IMAGE_PASSTHROUGH_GATEWAY</code> to <code>latest</code> tag</ul>


</details>


  </td>
  <td><a href="https://github.com/ArthurVardevanyan/HomeLab/pull/725/files#diff-8d9fa58cbcf5123089e5b9ceed7f7137b30e5b0bb5ecd39871f1688bf4984569">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>⚙️ Agent run details</strong></summary>

- Model: openai/qwen3.6-35b-a3b
- Tokens: 4,978 in / 4,035 out / 9,013 total
- Time cost: 29.0s
- AI calls: 1

</details>
